### PR TITLE
Use quanta for timings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ more-asserts = "0.2.1"
 
 [features]
 default = ["std", "dashmap", "quanta"]
-std = ["parking_lot", "evmap", "nonzero_ext/std", "futures-timer", "futures", "lazy_static"]
+std = ["parking_lot", "evmap", "nonzero_ext/std", "futures-timer", "futures"]
 no_std = []
 
 [dependencies]
@@ -70,4 +70,3 @@ futures = {version = "0.3.1", optional = true}
 rand = "0.7.2"
 dashmap = {version = "1.2.0", optional = true}
 quanta = {version = "0.3.1", optional = true}
-lazy_static = {version = "1.4.0", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ name = "criterion"
 harness = false
 
 [dev-dependencies]
-criterion = "0.2.11"
+criterion = "0.3.0"
 crossbeam = "0.7.3"
 libc = "0.2.41"
 futures = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ proptest = "0.9.4"
 more-asserts = "0.2.1"
 
 [features]
-default = ["std", "dashmap"]
-std = ["parking_lot", "evmap", "nonzero_ext/std", "futures-timer", "futures"]
+default = ["std", "dashmap", "quanta"]
+std = ["parking_lot", "evmap", "nonzero_ext/std", "futures-timer", "futures", "lazy_static"]
 no_std = []
 
 [dependencies]
@@ -69,3 +69,5 @@ futures-timer = {version = "2.0.0", optional = true}
 futures = {version = "0.3.1", optional = true}
 rand = "0.7.2"
 dashmap = {version = "1.2.0", optional = true}
+quanta = {version = "0.3.1", optional = true}
+lazy_static = {version = "1.4.0", optional = true}

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -8,6 +8,6 @@ criterion_group!(
     benches,
     realtime_clock::bench_all,
     single_threaded::bench_all,
-    multi_threaded::bench_all
+    multi_threaded::bench_all,
 );
 criterion_main!(benches);

--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -1,3 +1,7 @@
+//! Benchmarks measuring how long it takes a set of 20 threads to measure `iter` cells each.
+//! The longest-running thread's time is reported. These benchmarks unfortunately measure a certain
+//! amount of overhead in thread setup and teardown.
+
 use criterion::{black_box, BenchmarkId, Criterion, Throughput};
 use governor::state::keyed::{DashMapStateStore, HashMapStateStore, KeyedStateStore};
 use governor::{clock, Quota, RateLimiter};
@@ -19,22 +23,20 @@ fn bench_direct(c: &mut Criterion) {
     let mut group = c.benchmark_group("multi_threaded");
     group.throughput(Throughput::Elements(1));
     group.bench_function("direct", |b| {
-        let ms = Duration::from_millis(1);
-        let clock = clock::FakeRelativeClock::default();
-        let lim = Arc::new(RateLimiter::direct_with_clock(
-            Quota::per_second(nonzero!(50u32)),
-            &clock,
-        ));
+        let clock = clock::QuantaUpkeepClock::from_interval(Duration::from_micros(10))
+            .expect("Could not spawn upkeep thread");
 
         b.iter_custom(|iters| {
+            let lim = Arc::new(RateLimiter::direct_with_clock(
+                Quota::per_second(nonzero!(50u32)),
+                &clock,
+            ));
             let mut children = vec![];
             let start = Instant::now();
             for _i in 0..THREADS {
                 let lim = lim.clone();
-                let clock = clock.clone();
                 children.push(thread::spawn(move || {
                     for _i in 0..iters {
-                        clock.advance(ms);
                         black_box(lim.check().is_ok());
                     }
                 }));
@@ -55,24 +57,23 @@ fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mu
     group.throughput(Throughput::Elements(3));
 
     group.bench_function(BenchmarkId::new("keyed", type_name::<M>()), |b| {
-        let ms = Duration::from_millis(1);
-        let clock = clock::FakeRelativeClock::default();
-        let state: M = Default::default();
-        let lim = Arc::new(RateLimiter::new(
-            Quota::per_second(nonzero!(50u32)),
-            state,
-            &clock,
-        ));
+        let clock = clock::QuantaUpkeepClock::from_interval(Duration::from_micros(10))
+            .expect("Could not spawn upkeep thread");
 
         b.iter_custom(|iters| {
+            let state: M = Default::default();
+            let lim = Arc::new(RateLimiter::new(
+                Quota::per_second(nonzero!(50u32)),
+                state,
+                &clock,
+            ));
+
             let mut children = vec![];
             let start = Instant::now();
             for _i in 0..THREADS {
                 let lim = lim.clone();
-                let clock = clock.clone();
                 children.push(thread::spawn(move || {
                     for _i in 0..iters {
-                        clock.advance(ms);
                         black_box(lim.check_key(&1u32).is_ok());
                         black_box(lim.check_key(&2u32).is_ok());
                         black_box(lim.check_key(&3u32).is_ok());

--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -1,21 +1,24 @@
-use criterion::{black_box, BatchSize, Benchmark, Criterion, Throughput};
+use criterion::{black_box, BenchmarkId, Criterion, Throughput};
 use governor::state::keyed::{DashMapStateStore, HashMapStateStore, KeyedStateStore};
 use governor::{clock, Quota, RateLimiter};
 use nonzero_ext::*;
+use std::any::type_name;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 pub fn bench_all(c: &mut Criterion) {
     bench_direct(c);
-    bench_keyed::<HashMapStateStore<u32>>(c, "hashmap");
-    bench_keyed::<DashMapStateStore<u32>>(c, "dashmap");
+    bench_keyed::<HashMapStateStore<u32>>(c);
+    bench_keyed::<DashMapStateStore<u32>>(c);
 }
 
+const THREADS: u32 = 20;
+
 fn bench_direct(c: &mut Criterion) {
-    let id = "multi_threaded/direct";
-    let bm = Benchmark::new(id, |b| {
-        let mut children = vec![];
+    let mut group = c.benchmark_group("multi_threaded");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("direct", |b| {
         let ms = Duration::from_millis(1);
         let clock = clock::FakeRelativeClock::default();
         let lim = Arc::new(RateLimiter::direct_with_clock(
@@ -23,83 +26,64 @@ fn bench_direct(c: &mut Criterion) {
             &clock,
         ));
 
-        for _i in 0..19 {
-            let lim = lim.clone();
-            let clock = clock.clone();
-            let mut b = *b;
-            children.push(thread::spawn(move || {
-                b.iter_batched(
-                    || {
+        b.iter_custom(|iters| {
+            let mut children = vec![];
+            let start = Instant::now();
+            for _i in 0..THREADS {
+                let lim = lim.clone();
+                let clock = clock.clone();
+                children.push(thread::spawn(move || {
+                    for _i in 0..iters {
                         clock.advance(ms);
-                    },
-                    |()| {
                         black_box(lim.check().is_ok());
-                    },
-                    BatchSize::SmallInput,
-                );
-            }));
-        }
-        b.iter(|| {
-            clock.advance(ms);
-            black_box(lim.check().is_ok());
-        });
-        for child in children {
-            child.join().unwrap();
-        }
-    })
-    .throughput(Throughput::Elements(1));
-    c.bench(id, bm);
+                    }
+                }));
+            }
+            for child in children {
+                child.join().unwrap()
+            }
+            start.elapsed()
+        })
+    });
+    group.finish();
 }
 
-fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(
-    c: &mut Criterion,
-    name: &str,
-) {
-    let id = format!("multi_threaded/keyed/{}", name);
-    let bm = Benchmark::new(&id, |b| {
-        let mut children = vec![];
-        let state: M = Default::default();
+fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mut Criterion) {
+    let mut group = c.benchmark_group("multi_threaded");
+
+    // We perform 3 checks per thread per iter:
+    group.throughput(Throughput::Elements(3));
+
+    group.bench_function(BenchmarkId::new("keyed", type_name::<M>()), |b| {
         let ms = Duration::from_millis(1);
         let clock = clock::FakeRelativeClock::default();
+        let state: M = Default::default();
         let lim = Arc::new(RateLimiter::new(
             Quota::per_second(nonzero!(50u32)),
             state,
             &clock,
         ));
 
-        for _i in 0..19 {
-            let lim = lim.clone();
-            let clock = clock.clone();
-            let mut b = *b;
-            children.push(thread::spawn(move || {
-                b.iter_batched(
-                    || {
+        b.iter_custom(|iters| {
+            let mut children = vec![];
+            let start = Instant::now();
+            for _i in 0..THREADS {
+                let lim = lim.clone();
+                let clock = clock.clone();
+                children.push(thread::spawn(move || {
+                    for _i in 0..iters {
                         clock.advance(ms);
-                    },
-                    |()| {
                         black_box(lim.check_key(&1u32).is_ok());
                         black_box(lim.check_key(&2u32).is_ok());
                         black_box(lim.check_key(&3u32).is_ok());
-                    },
-                    BatchSize::SmallInput,
-                );
-            }));
-        }
-        b.iter_batched(
-            || {
-                clock.advance(ms);
-            },
-            |()| {
-                black_box(lim.check_key(&1u32).is_ok());
-                black_box(lim.check_key(&2u32).is_ok());
-                black_box(lim.check_key(&3u32).is_ok());
-            },
-            BatchSize::SmallInput,
-        );
-        for child in children {
-            child.join().unwrap();
-        }
-    })
-    .throughput(Throughput::Elements(3));
-    c.bench(&id, bm);
+                    }
+                }));
+            }
+            for child in children {
+                child.join().unwrap()
+            }
+            start.elapsed()
+        })
+    });
+    group.finish();
 }

--- a/benches/realtime_clock.rs
+++ b/benches/realtime_clock.rs
@@ -4,8 +4,8 @@
 //! (allowing max_value of `u32` per nanosecond), and one that mostly denies (allowing only one
 //! per hour).
 
-use criterion::{black_box, Benchmark, Criterion, Throughput};
-use governor::{Quota, RateLimiter};
+use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+use governor::{clock, Quota, RateLimiter};
 use nonzero_ext::*;
 use std::time::Duration;
 
@@ -14,28 +14,48 @@ pub fn bench_all(c: &mut Criterion) {
     bench_mostly_deny(c);
 }
 
+macro_rules! with_realtime_clocks {
+    {($name:expr, $group:ident) |$b:pat, $clock:pat| $closure:block} => {
+        {
+            let clock = clock::MonotonicClock::default();
+            $group.throughput(Throughput::Elements(1));
+            $group.bench_with_input(BenchmarkId::new($name, "MonotonicClock"), &clock, |$b, $clock| $closure);
+        }
+        {
+            let clock = clock::QuantaClock::default();
+            $group.throughput(Throughput::Elements(1));
+            $group.bench_with_input(BenchmarkId::new($name, "QuantaClock"), &clock, |$b, $clock| $closure);
+        }
+        {
+            let clock = clock::QuantaUpkeepClock::from_interval(Duration::from_micros(40))
+                .expect("could not spawn upkeep thread");
+            $group.throughput(Throughput::Elements(1));
+            $group.bench_with_input(BenchmarkId::new($name, "QuantaUpkeepClock"), &clock, |$b, $clock| $closure);
+        }
+    };
+}
+
 fn bench_mostly_allow(c: &mut Criterion) {
-    let id = "realtime_clock/mostly_allow";
-    let bm = Benchmark::new(id, |b| {
-        let rl = RateLimiter::direct(
+    let mut group = c.benchmark_group("realtime_clock");
+    with_realtime_clocks! {("mostly_allow", group) |b, clock| {
+        let rl = RateLimiter::direct_with_clock(
             Quota::new(nonzero!(u32::max_value()), Duration::from_nanos(1)).unwrap(),
+            clock
         );
         b.iter(|| {
             black_box(rl.check().is_ok());
         });
-    })
-    .throughput(Throughput::Elements(1));
-    c.bench(id, bm);
+    }};
+    group.finish();
 }
 
 fn bench_mostly_deny(c: &mut Criterion) {
-    let id = "realtime_clock/mostly_deny";
-    let bm = Benchmark::new(id, |b| {
-        let rl = RateLimiter::direct(Quota::per_hour(nonzero!(1u32)));
+    let mut group = c.benchmark_group("realtime_clock");
+    with_realtime_clocks! {("mostly_deny", group) |b, clock| {
+        let rl = RateLimiter::direct_with_clock(Quota::per_hour(nonzero!(1u32)), clock);
         b.iter(|| {
             black_box(rl.check().is_ok());
         });
-    })
-    .throughput(Throughput::Elements(1));
-    c.bench(id, bm);
+    }};
+    group.finish();
 }

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -1,18 +1,20 @@
-use criterion::{black_box, BatchSize, Benchmark, Criterion, Throughput};
+use criterion::{black_box, BatchSize, BenchmarkId, Criterion, Throughput};
 use governor::state::keyed::{DashMapStateStore, HashMapStateStore, KeyedStateStore};
 use governor::{clock, Quota, RateLimiter};
 use nonzero_ext::*;
+use std::any::type_name;
 use std::time::Duration;
 
 pub fn bench_all(c: &mut Criterion) {
     bench_direct(c);
-    bench_keyed::<HashMapStateStore<u32>>(c, "hashmap");
-    bench_keyed::<DashMapStateStore<u32>>(c, "dashmap");
+    bench_keyed::<HashMapStateStore<u32>>(c);
+    bench_keyed::<DashMapStateStore<u32>>(c);
 }
 
 fn bench_direct(c: &mut Criterion) {
-    let id = "single_threaded/direct";
-    let bm = Benchmark::new(id, |b| {
+    let mut group = c.benchmark_group("single_threaded");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("direct", |b| {
         let clock = clock::FakeRelativeClock::default();
         let step = Duration::from_millis(20);
         let rl = RateLimiter::direct_with_clock(Quota::per_second(nonzero!(50u32)), &clock);
@@ -25,31 +27,30 @@ fn bench_direct(c: &mut Criterion) {
             },
             BatchSize::SmallInput,
         );
-    })
-    .throughput(Throughput::Elements(1));
-    c.bench(id, bm);
+    });
+    group.finish();
 }
 
-fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(
-    c: &mut Criterion,
-    name: &str,
-) {
-    let id = format!("single_threaded/keyed/{}", name);
-    let bm = Benchmark::new(&id, |b| {
-        let state: M = Default::default();
-        let clock = clock::FakeRelativeClock::default();
-        let step = Duration::from_millis(20);
-        let rl = RateLimiter::new(Quota::per_second(nonzero!(50u32)), state, &clock);
-        b.iter_batched(
-            || {
-                clock.advance(step);
-            },
-            |()| {
-                black_box(rl.check_key(&1u32).is_ok());
-            },
-            BatchSize::SmallInput,
-        );
-    })
-    .throughput(Throughput::Elements(1));
-    c.bench(&id, bm);
+fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mut Criterion) {
+    let mut group = c.benchmark_group("single_threaded");
+    group.throughput(Throughput::Elements(3));
+
+    group
+        .bench_function(BenchmarkId::new("keyed", type_name::<M>()), |b| {
+            let state: M = Default::default();
+            let clock = clock::FakeRelativeClock::default();
+            let step = Duration::from_millis(20);
+            let rl = RateLimiter::new(Quota::per_second(nonzero!(50u32)), state, &clock);
+            b.iter_batched(
+                || {
+                    clock.advance(step);
+                },
+                |()| {
+                    black_box(rl.check_key(&1u32).is_ok());
+                },
+                BatchSize::SmallInput,
+            );
+        })
+        .throughput(Throughput::Elements(1));
+    group.finish();
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -31,14 +31,6 @@ pub trait Clock: Clone {
     fn now(&self) -> Self::Instant;
 }
 
-/// A clock reference is compatible with another reference.
-///
-/// The purpose of this trait is to restrict availability of the `async` functions, as they
-/// wait real amounts of time - if a measurement is "off" or fake, the async function would still
-/// cause the program to wait, but be unable to make progress because the rate limiter is on
-/// another clock.  
-pub trait CompatibleConversion<O>: Reference {}
-
 impl Reference for Duration {
     fn duration_since(&self, earlier: Self) -> Nanos {
         self.checked_sub(earlier)
@@ -50,9 +42,6 @@ impl Reference for Duration {
         self.checked_sub(duration.into()).unwrap_or(*self)
     }
 }
-
-/// Every instant is compatible with itself.
-impl<T: Reference> CompatibleConversion<T> for T {}
 
 impl Add<Nanos> for Duration {
     type Output = Self;

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -31,6 +31,14 @@ pub trait Clock: Clone {
     fn now(&self) -> Self::Instant;
 }
 
+/// A clock reference is compatible with another reference.
+///
+/// The purpose of this trait is to restrict availability of the `async` functions, as they
+/// wait real amounts of time - if a measurement is "off" or fake, the async function would still
+/// cause the program to wait, but be unable to make progress because the rate limiter is on
+/// another clock.  
+pub trait CompatibleConversion<O>: Reference {}
+
 impl Reference for Duration {
     fn duration_since(&self, earlier: Self) -> Nanos {
         self.checked_sub(earlier)
@@ -42,6 +50,9 @@ impl Reference for Duration {
         self.checked_sub(duration.into()).unwrap_or(*self)
     }
 }
+
+/// Every instant is compatible with itself.
+impl<T: Reference> CompatibleConversion<T> for T {}
 
 impl Add<Nanos> for Duration {
     type Output = Self;

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -97,3 +97,11 @@ pub use no_std::*;
 mod with_std;
 #[cfg(feature = "std")]
 pub use with_std::*;
+
+#[cfg(all(feature = "std", feature = "quanta"))]
+mod quanta;
+#[cfg(all(feature = "std", feature = "quanta"))]
+pub use self::quanta::*;
+
+mod default;
+pub use default::*;

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -8,18 +8,18 @@ use crate::lib::*;
 
 /// A measurement from a clock.
 pub trait Reference:
-    Sized + Add<Duration, Output = Self> + PartialEq + Eq + Ord + Copy + Clone + Send + Sync + Debug
+    Sized + Add<Nanos, Output = Self> + PartialEq + Eq + Ord + Copy + Clone + Send + Sync + Debug
 {
     /// Determines the time that separates two measurements of a
     /// clock. Implementations of this must perform a saturating
     /// subtraction - if the `earlier` timestamp should be later,
     /// `duration_since` must return the zero duration.
-    fn duration_since(&self, earlier: Self) -> Duration;
+    fn duration_since(&self, earlier: Self) -> Nanos;
 
     /// Returns a reference point that lies at most `duration` in the
     /// past from the current reference. If an underflow should occur,
     /// returns the current reference.
-    fn saturating_sub(&self, duration: Duration) -> Self;
+    fn saturating_sub(&self, duration: Nanos) -> Self;
 }
 
 /// A time source used by rate limiters.
@@ -32,13 +32,23 @@ pub trait Clock: Clone {
 }
 
 impl Reference for Duration {
-    fn duration_since(&self, earlier: Self) -> Duration {
+    fn duration_since(&self, earlier: Self) -> Nanos {
         self.checked_sub(earlier)
             .unwrap_or_else(|| Duration::new(0, 0))
+            .into()
     }
 
-    fn saturating_sub(&self, duration: Duration) -> Self {
-        self.checked_sub(duration).unwrap_or(*self)
+    fn saturating_sub(&self, duration: Nanos) -> Self {
+        self.checked_sub(duration.into()).unwrap_or(*self)
+    }
+}
+
+impl Add<Nanos> for Duration {
+    type Output = Self;
+
+    fn add(self, other: Nanos) -> Self {
+        let other: Duration = other.into();
+        self + other
     }
 }
 
@@ -81,10 +91,10 @@ impl PartialEq for FakeRelativeClock {
 }
 
 impl Clock for FakeRelativeClock {
-    type Instant = Duration;
+    type Instant = Nanos;
 
     fn now(&self) -> Self::Instant {
-        Duration::from_nanos(self.now.load(Ordering::Relaxed))
+        self.now.load(Ordering::Relaxed).into()
     }
 }
 
@@ -104,4 +114,6 @@ mod quanta;
 pub use self::quanta::*;
 
 mod default;
+
+use crate::nanos::Nanos;
 pub use default::*;

--- a/src/clock/default.rs
+++ b/src/clock/default.rs
@@ -1,5 +1,5 @@
 #[cfg(all(feature = "std", not(feature = "quanta")))]
-/// The default clock that reports [`Instant`]s.
+/// The default clock that reports [`Instant`][std::time::Instant]s.
 pub type DefaultClock = crate::clock::MonotonicClock;
 
 #[cfg(all(feature = "std", feature = "quanta"))]
@@ -7,5 +7,6 @@ pub type DefaultClock = crate::clock::MonotonicClock;
 pub type DefaultClock = crate::clock::QuantaClock;
 
 #[cfg(not(feature = "std"))]
-/// The default `no_std` clock that reports [`Durations`] must be advanced by the program.
+/// The default `no_std` clock that reports [`Durations`][core::time::Duration] must be advanced by the
+/// program.
 pub type DefaultClock = crate::clock::FakeRelativeClock;

--- a/src/clock/default.rs
+++ b/src/clock/default.rs
@@ -1,0 +1,11 @@
+#[cfg(all(feature = "std", not(feature = "quanta")))]
+/// The default clock that reports [`Instant`]s.
+pub type DefaultClock = crate::clock::MonotonicClock;
+
+#[cfg(all(feature = "std", feature = "quanta"))]
+/// The default clock using [`quanta`] for extremely fast timekeeping (at a 100ns resolution).
+pub type DefaultClock = crate::clock::QuantaClock;
+
+#[cfg(not(feature = "std"))]
+/// The default `no_std` clock that reports [`Durations`] must be advanced by the program.
+pub type DefaultClock = crate::clock::FakeRelativeClock;

--- a/src/clock/no_std.rs
+++ b/src/clock/no_std.rs
@@ -1,4 +1,1 @@
 use super::FakeRelativeClock;
-
-/// The default `no_std` clock that reports [`Durations`] must be advanced by the program.
-pub type DefaultClock = FakeRelativeClock;

--- a/src/clock/quanta.rs
+++ b/src/clock/quanta.rs
@@ -1,8 +1,9 @@
 use crate::lib::*;
 
-use crate::clock::{Clock, Reference};
+use crate::clock::{Clock, CompatibleConversion, Reference};
 use crate::nanos::Nanos;
 use quanta;
+use std::time::SystemTime;
 
 /// A clock using the default [`quanta::Clock`] structure.
 ///
@@ -49,6 +50,10 @@ impl Reference for QuantaInstant {
         QuantaInstant(self.0.saturating_sub(duration))
     }
 }
+
+impl CompatibleConversion<Instant> for QuantaInstant {}
+
+impl CompatibleConversion<SystemTime> for QuantaInstant {}
 
 /// A clock using the default [`quanta::Clock`] structure and an upkeep thread.
 ///

--- a/src/clock/quanta.rs
+++ b/src/clock/quanta.rs
@@ -1,31 +1,91 @@
 use crate::lib::*;
 
-use crate::clock::Clock;
+use crate::clock::{Clock, Reference};
 use crate::nanos::Nanos;
-use lazy_static::*;
 use quanta;
 
-/// A clock using the [`quanta`] crate.
+/// A clock using the default [`quanta::Clock`] structure.
 ///
-/// It works by keeping a time keeping thread that updates a reference time every 100ns.
+/// This clock uses [`quanta::Clock.now`], which does retrieve the time synchronously. To use a
+/// clock that uses a quanta background upkeep thread (which allows retrieving the time with an
+/// atomic read, but requires a background thread that wakes up continually),
+/// see [`QuantaUpkeepClock`].
 #[derive(Debug, Clone)]
 pub struct QuantaClock(quanta::Clock);
 
 impl Default for QuantaClock {
     fn default() -> Self {
-        lazy_static! {
-            static ref HANDLE: quanta::Handle = quanta::Builder::new(Duration::from_nanos(100))
-                .start()
-                .expect("should build the reference handle");
-        }
         QuantaClock(Default::default())
     }
 }
 
 impl Clock for QuantaClock {
-    type Instant = Nanos;
+    type Instant = QuantaInstant;
 
     fn now(&self) -> Self::Instant {
-        Nanos::from(self.0.recent())
+        QuantaInstant(Nanos::from(self.0.now()))
+    }
+}
+
+/// A nanosecond-scale opaque instant (already scaled to reference time) returned from a
+/// [`QuantaClock`].
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct QuantaInstant(Nanos);
+
+impl Add<Nanos> for QuantaInstant {
+    type Output = QuantaInstant;
+
+    fn add(self, other: Nanos) -> QuantaInstant {
+        QuantaInstant(self.0 + other)
+    }
+}
+
+impl Reference for QuantaInstant {
+    fn duration_since(&self, earlier: Self) -> Nanos {
+        self.0.duration_since(earlier.0)
+    }
+
+    fn saturating_sub(&self, duration: Nanos) -> Self {
+        QuantaInstant(self.0.saturating_sub(duration))
+    }
+}
+
+/// A clock using the default [`quanta::Clock`] structure and an upkeep thread.
+///
+/// This clock relies on an upkeep thread that wakes up in regular (user defined) intervals to
+/// retrieve the current time and update an atomic U64; the clock then can retrieve that time
+/// (and is as behind as, at most, that interval).
+///
+/// The background thread is stopped as soon as the last clone of the clock is
+/// dropped.
+///
+/// Whether this is faster than a [`QuantaClock`] depends on the utilization of the rate limiter
+/// and the upkeep interval that you pick; you should measure and compare performance before
+/// picking one or the other.
+#[derive(Debug, Clone)]
+pub struct QuantaUpkeepClock(quanta::Clock, Arc<quanta::Handle>);
+
+impl QuantaUpkeepClock {
+    /// Returns a new `QuantaUpkeepClock` with an upkeep thread that wakes up once in `interval`.
+    pub fn from_interval(interval: Duration) -> Result<QuantaUpkeepClock, std::io::Error> {
+        let builder = quanta::Builder::new(interval);
+        Self::from_builder(builder)
+    }
+
+    /// Returns a new `QuantaUpkeepClock` with an upkeep thread as specified by the given builder.
+    pub fn from_builder(builder: quanta::Builder) -> Result<QuantaUpkeepClock, std::io::Error> {
+        let handle = builder.start()?;
+        Ok(QuantaUpkeepClock(
+            quanta::Clock::default(),
+            Arc::new(handle),
+        ))
+    }
+}
+
+impl Clock for QuantaUpkeepClock {
+    type Instant = QuantaInstant;
+
+    fn now(&self) -> Self::Instant {
+        QuantaInstant(Nanos::from(self.0.recent()))
     }
 }

--- a/src/clock/quanta.rs
+++ b/src/clock/quanta.rs
@@ -1,0 +1,31 @@
+use crate::lib::*;
+
+use crate::clock::Clock;
+use crate::nanos::Nanos;
+use lazy_static::*;
+use quanta;
+
+/// A clock using the [`quanta`] crate.
+///
+/// It works by keeping a time keeping thread that updates a reference time every 100ns.
+#[derive(Debug, Clone)]
+pub struct QuantaClock(quanta::Clock);
+
+impl Default for QuantaClock {
+    fn default() -> Self {
+        lazy_static! {
+            static ref HANDLE: quanta::Handle = quanta::Builder::new(Duration::from_nanos(100))
+                .start()
+                .expect("should build the reference handle");
+        }
+        QuantaClock(Default::default())
+    }
+}
+
+impl Clock for QuantaClock {
+    type Instant = Nanos;
+
+    fn now(&self) -> Self::Instant {
+        Nanos::from(self.0.recent())
+    }
+}

--- a/src/clock/with_std.rs
+++ b/src/clock/with_std.rs
@@ -4,9 +4,6 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
-/// The default clock that reports [`Instant`]s.
-pub type DefaultClock = MonotonicClock;
-
 /// A mock implementation of a clock tracking [`Instant`]s. All it
 /// does is keep track of what "now" is by allowing the program to
 /// increment the current time (taken at time of construction) by some

--- a/src/clock/with_std.rs
+++ b/src/clock/with_std.rs
@@ -1,6 +1,6 @@
 use crate::lib::*;
 
-use super::{Clock, Reference};
+use super::{Clock, CompatibleConversion, Reference};
 
 use crate::nanos::Nanos;
 use std::time::{Duration, Instant, SystemTime};
@@ -31,6 +31,8 @@ impl Reference for Instant {
         self.checked_sub(duration.into()).unwrap_or(*self)
     }
 }
+
+impl CompatibleConversion<SystemTime> for Instant {}
 
 impl Clock for MonotonicClock {
     type Instant = Instant;

--- a/src/clock/with_std.rs
+++ b/src/clock/with_std.rs
@@ -1,56 +1,34 @@
+use crate::lib::*;
+
 use super::{Clock, Reference};
 
-use parking_lot::Mutex;
-use std::sync::Arc;
+use crate::nanos::Nanos;
 use std::time::{Duration, Instant, SystemTime};
-
-/// A mock implementation of a clock tracking [`Instant`]s. All it
-/// does is keep track of what "now" is by allowing the program to
-/// increment the current time (taken at time of construction) by some
-/// arbitrary [`Duration`].
-#[derive(Debug, Clone)]
-pub struct FakeAbsoluteClock {
-    now: Arc<Mutex<Instant>>,
-}
-
-impl Default for FakeAbsoluteClock {
-    fn default() -> Self {
-        FakeAbsoluteClock {
-            now: Arc::new(Mutex::new(Instant::now())),
-        }
-    }
-}
-
-impl FakeAbsoluteClock {
-    /// Advances the fake clock by the given amount.
-    pub fn advance(&mut self, by: Duration) {
-        *(self.now.lock()) += by
-    }
-}
-
-impl Clock for FakeAbsoluteClock {
-    type Instant = Instant;
-
-    fn now(&self) -> Self::Instant {
-        *self.now.lock()
-    }
-}
 
 /// The monotonic clock implemented by [`Instant`].
 #[derive(Clone, Debug, Default)]
 pub struct MonotonicClock();
 
+impl Add<Nanos> for Instant {
+    type Output = Instant;
+
+    fn add(self, other: Nanos) -> Instant {
+        let other: Duration = other.into();
+        self + other
+    }
+}
+
 impl Reference for Instant {
-    fn duration_since(&self, earlier: Self) -> Duration {
+    fn duration_since(&self, earlier: Self) -> Nanos {
         if earlier < *self {
-            *self - earlier
+            (*self - earlier).into()
         } else {
-            Duration::new(0, 0)
+            Nanos::from(Duration::new(0, 0))
         }
     }
 
-    fn saturating_sub(&self, duration: Duration) -> Self {
-        self.checked_sub(duration).unwrap_or(*self)
+    fn saturating_sub(&self, duration: Nanos) -> Self {
+        self.checked_sub(duration.into()).unwrap_or(*self)
     }
 }
 
@@ -71,13 +49,23 @@ impl Reference for SystemTime {
     /// SystemTimes. Due to the fallible nature of SystemTimes,
     /// returns the zero duration if a negative duration would
     /// result (e.g. due to system clock adjustments).
-    fn duration_since(&self, earlier: Self) -> Duration {
+    fn duration_since(&self, earlier: Self) -> Nanos {
         self.duration_since(earlier)
             .unwrap_or_else(|_| Duration::new(0, 0))
+            .into()
     }
 
-    fn saturating_sub(&self, duration: Duration) -> Self {
-        self.checked_sub(duration).unwrap_or(*self)
+    fn saturating_sub(&self, duration: Nanos) -> Self {
+        self.checked_sub(duration.into()).unwrap_or(*self)
+    }
+}
+
+impl Add<Nanos> for SystemTime {
+    type Output = SystemTime;
+
+    fn add(self, other: Nanos) -> SystemTime {
+        let other: Duration = other.into();
+        self + other
     }
 }
 

--- a/src/clock/with_std.rs
+++ b/src/clock/with_std.rs
@@ -110,7 +110,7 @@ impl ReasonablyRealtime for SystemClock {
     ) -> Instant {
         let diff = reading
             .duration_since(reference.0)
-            .unwrap_or(Duration::new(0, 0));
+            .unwrap_or_else(|_| Duration::new(0, 0));
         reference.1 + diff
     }
 }

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -1,7 +1,7 @@
 use crate::lib::*;
 use crate::nanos::Nanos;
 use crate::state::StateStore;
-use crate::{clock, NegativeMultiDecision, Quota};
+use crate::{clock, Jitter, NegativeMultiDecision, Quota};
 
 /// A negative rate-limiting outcome.
 ///
@@ -32,6 +32,11 @@ impl<'a, P: clock::Reference> NotUntil<'a, P> {
     pub fn wait_time_from(&self, from: P) -> Duration {
         let earliest = self.earliest_possible();
         earliest.duration_since(earliest.min(from)).into()
+    }
+
+    pub(crate) fn earliest_possible_with_offset(&self, jitter: Jitter) -> P {
+        let tat = jitter + self.tat;
+        self.start + tat
     }
 }
 

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -74,6 +74,9 @@ impl Jitter {
 
     /// Returns a random amount of jitter within the configured interval.
     pub(crate) fn get(&self) -> Nanos {
+        if self.min == self.max {
+            return self.min;
+        }
         let uniform = Uniform::new(self.min, self.max);
         uniform.sample(&mut thread_rng())
     }

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -53,8 +53,8 @@ impl Jitter {
     #[cfg(feature = "std")]
     /// The "empty" jitter interval - no jitter at all.
     pub(crate) const NONE: Jitter = Jitter {
-        min: Nanos::from(0),
-        max: Nanos::from(0),
+        min: Nanos::new(0),
+        max: Nanos::new(0),
     };
 
     /// Constructs a new Jitter interval, waiting at most a duration of `max`.
@@ -66,7 +66,7 @@ impl Jitter {
     }
 
     /// Constructs a new Jitter interval, waiting at least `min` and at most `min+interval`.
-    pub const fn new(min: Duration, interval: Duration) -> Jitter {
+    pub fn new(min: Duration, interval: Duration) -> Jitter {
         let min: Nanos = min.into();
         let max: Nanos = min + Nanos::from(interval);
         Jitter { min, max }
@@ -74,13 +74,14 @@ impl Jitter {
 
     /// Returns a random amount of jitter within the configured interval.
     pub(crate) fn get(&self) -> Nanos {
-        let mut uniform = Uniform::new(self.min, self.max);
+        let uniform = Uniform::new(self.min, self.max);
         uniform.sample(&mut thread_rng())
     }
 }
 
+/// A random distribution of nanoseconds
 #[derive(Clone, Copy, Debug)]
-struct UniformJitter(UniformInt<u64>);
+pub struct UniformJitter(UniformInt<u64>);
 
 impl UniformSampler for UniformJitter {
     type X = Nanos;

--- a/src/nanos.rs
+++ b/src/nanos.rs
@@ -1,5 +1,6 @@
 //! A time-keeping abstraction (nanoseconds) that works for storing in an atomic integer.
 
+use crate::clock;
 use crate::lib::*;
 
 /// A number of nanoseconds from a reference point.
@@ -41,14 +42,6 @@ impl Add<Nanos> for Nanos {
     }
 }
 
-impl Mul<Nanos> for Nanos {
-    type Output = Nanos;
-
-    fn mul(self, rhs: Nanos) -> Self::Output {
-        Nanos(self.0 * rhs.0)
-    }
-}
-
 impl Mul<u64> for Nanos {
     type Output = Nanos;
 
@@ -86,5 +79,24 @@ impl Into<Duration> for Nanos {
 impl Nanos {
     pub(crate) fn saturating_sub(self, rhs: Nanos) -> Nanos {
         Nanos(self.0.saturating_sub(rhs.0))
+    }
+}
+
+impl clock::Reference for Nanos {
+    fn duration_since(&self, earlier: Self) -> Duration {
+        Duration::from_nanos((*self as Nanos).saturating_sub(earlier).0)
+    }
+
+    fn saturating_sub(&self, duration: Duration) -> Self {
+        (*self as Nanos).saturating_sub(duration.into())
+    }
+}
+
+impl Add<Duration> for Nanos {
+    type Output = Self;
+
+    fn add(self, other: Duration) -> Self {
+        let other: Nanos = other.into();
+        self + other
     }
 }

--- a/src/nanos.rs
+++ b/src/nanos.rs
@@ -83,12 +83,12 @@ impl Nanos {
 }
 
 impl clock::Reference for Nanos {
-    fn duration_since(&self, earlier: Self) -> Duration {
-        Duration::from_nanos((*self as Nanos).saturating_sub(earlier).0)
+    fn duration_since(&self, earlier: Self) -> Nanos {
+        (*self as Nanos).saturating_sub(earlier)
     }
 
-    fn saturating_sub(&self, duration: Duration) -> Self {
-        (*self as Nanos).saturating_sub(duration.into())
+    fn saturating_sub(&self, duration: Nanos) -> Self {
+        (*self as Nanos).saturating_sub(duration)
     }
 }
 

--- a/src/nanos.rs
+++ b/src/nanos.rs
@@ -14,6 +14,10 @@ impl Nanos {
     pub(crate) fn as_u64(self) -> u64 {
         self.0
     }
+
+    pub(crate) const fn new(u: u64) -> Self {
+        Nanos(u)
+    }
 }
 
 impl From<Duration> for Nanos {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,7 @@
 //! State stores for rate limiters
 
+use crate::lib::*;
+
 pub mod direct;
 mod in_memory;
 pub mod keyed;
@@ -79,5 +81,24 @@ where
             gcra,
             start,
         }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<K, S, C> RateLimiter<K, S, C>
+where
+    S: StateStore<Key = K>,
+    C: clock::ReasonablyRealtime,
+{
+    pub(crate) fn reference_reading(&self) -> (C::Instant, Instant) {
+        self.clock.reference_point()
+    }
+
+    pub(crate) fn instant_from_reference(
+        &self,
+        reference: (C::Instant, Instant),
+        reading: C::Instant,
+    ) -> Instant {
+        C::convert_from_reference(reference, reading)
     }
 }

--- a/src/state/direct.rs
+++ b/src/state/direct.rs
@@ -32,10 +32,10 @@ impl<T> DirectStateStore for T where T: StateStore<Key = NotKeyed> {}
 /// or to ensure that an API client stays within a service's rate
 /// limit.
 #[cfg(feature = "std")]
-impl RateLimiter<NotKeyed, InMemoryState, clock::MonotonicClock> {
-    /// Construct a new in-memory direct rate limiter for a quota with the monotonic clock.
-    pub fn direct(quota: Quota) -> RateLimiter<NotKeyed, InMemoryState, clock::MonotonicClock> {
-        let clock = clock::MonotonicClock::default();
+impl RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock> {
+    /// Constructs a new in-memory direct rate limiter for a quota with the default real-time clock.
+    pub fn direct(quota: Quota) -> RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock> {
+        let clock = clock::DefaultClock::default();
         Self::direct_with_clock(quota, &clock)
     }
 }
@@ -44,7 +44,7 @@ impl<C> RateLimiter<NotKeyed, InMemoryState, C>
 where
     C: clock::Clock,
 {
-    /// Construct a new direct rate limiter for a quota with a custom clock.
+    /// Constructs a new direct rate limiter for a quota with a custom clock.
     pub fn direct_with_clock(quota: Quota, clock: &C) -> Self {
         let state: InMemoryState = Default::default();
         RateLimiter::new(quota, state, &clock)

--- a/src/state/direct/future.rs
+++ b/src/state/direct/future.rs
@@ -1,3 +1,5 @@
+use crate::lib::*;
+
 use super::RateLimiter;
 use crate::{
     clock::{self, Clock},
@@ -8,9 +10,11 @@ use futures_timer::Delay;
 
 #[cfg(feature = "std")]
 /// # Direct rate limiters - `async`/`await`
-impl<S> RateLimiter<NotKeyed, S, clock::MonotonicClock>
+impl<S, C> RateLimiter<NotKeyed, S, C>
 where
     S: DirectStateStore,
+    C: Clock,
+    C::Instant: clock::CompatibleConversion<Instant>,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/src/state/direct/future.rs
+++ b/src/state/direct/future.rs
@@ -1,8 +1,6 @@
-use crate::lib::*;
-
 use super::RateLimiter;
 use crate::{
-    clock::{self, Clock},
+    clock,
     state::{DirectStateStore, NotKeyed},
     Jitter,
 };
@@ -13,8 +11,7 @@ use futures_timer::Delay;
 impl<S, C> RateLimiter<NotKeyed, S, C>
 where
     S: DirectStateStore,
-    C: Clock,
-    C::Instant: clock::CompatibleConversion<Instant>,
+    C: clock::ReasonablyRealtime,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/src/state/direct/streams.rs
+++ b/src/state/direct/streams.rs
@@ -17,12 +17,13 @@ pub trait StreamRateLimitExt<'a>: Stream {
     /// The combinator will buffer at most one item in order to adhere to the
     /// given limiter. I.e. if it already has an item buffered and needs to wait
     /// it will not `poll` the underlying stream.
-    fn ratelimit_stream<D: DirectStateStore>(
+    fn ratelimit_stream<D: DirectStateStore, C: clock::Clock>(
         self,
-        limiter: &'a RateLimiter<NotKeyed, D, clock::MonotonicClock>,
-    ) -> RatelimitedStream<'a, Self, D>
+        limiter: &'a RateLimiter<NotKeyed, D, C>,
+    ) -> RatelimitedStream<'a, Self, D, C>
     where
-        Self: Sized;
+        Self: Sized,
+        C::Instant: clock::CompatibleConversion<Instant>;
 
     /// Limits the rate at which the stream produces items, with a randomized wait period.
     ///
@@ -31,33 +32,36 @@ pub trait StreamRateLimitExt<'a>: Stream {
     /// The combinator will buffer at most one item in order to adhere to the
     /// given limiter. I.e. if it already has an item buffered and needs to wait
     /// it will not `poll` the underlying stream.
-    fn ratelimit_stream_with_jitter<D: DirectStateStore>(
+    fn ratelimit_stream_with_jitter<D: DirectStateStore, C: clock::Clock>(
         self,
-        limiter: &'a RateLimiter<NotKeyed, D, clock::MonotonicClock>,
+        limiter: &'a RateLimiter<NotKeyed, D, C>,
         jitter: Jitter,
-    ) -> RatelimitedStream<'a, Self, D>
+    ) -> RatelimitedStream<'a, Self, D, C>
     where
-        Self: Sized;
+        Self: Sized,
+        C::Instant: clock::CompatibleConversion<Instant>;
 }
 
 impl<'a, S: Stream> StreamRateLimitExt<'a> for S {
-    fn ratelimit_stream<D: DirectStateStore>(
+    fn ratelimit_stream<D: DirectStateStore, C: clock::Clock>(
         self,
-        limiter: &'a RateLimiter<NotKeyed, D, clock::MonotonicClock>,
-    ) -> RatelimitedStream<'a, Self, D>
+        limiter: &'a RateLimiter<NotKeyed, D, C>,
+    ) -> RatelimitedStream<'a, Self, D, C>
     where
         Self: Sized,
+        C::Instant: clock::CompatibleConversion<Instant>,
     {
         self.ratelimit_stream_with_jitter(limiter, Jitter::NONE)
     }
 
-    fn ratelimit_stream_with_jitter<D: DirectStateStore>(
+    fn ratelimit_stream_with_jitter<D: DirectStateStore, C: clock::Clock>(
         self,
-        limiter: &'a RateLimiter<NotKeyed, D, clock::MonotonicClock>,
+        limiter: &'a RateLimiter<NotKeyed, D, C>,
         jitter: Jitter,
-    ) -> RatelimitedStream<'a, Self, D>
+    ) -> RatelimitedStream<'a, Self, D, C>
     where
         Self: Sized,
+        C::Instant: clock::CompatibleConversion<Instant>,
     {
         RatelimitedStream {
             inner: self,
@@ -81,9 +85,9 @@ enum State {
 ///
 /// This is produced by the [`StreamRateLimitExt::ratelimit_stream`] and
 /// [`StreamRateLimitExt::ratelimit_stream_with_jitter`] methods.
-pub struct RatelimitedStream<'a, S: Stream, D: DirectStateStore> {
+pub struct RatelimitedStream<'a, S: Stream, D: DirectStateStore, C: clock::Clock> {
     inner: S,
-    limiter: &'a RateLimiter<NotKeyed, D, clock::MonotonicClock>,
+    limiter: &'a RateLimiter<NotKeyed, D, C>,
     delay: Delay,
     buf: Option<S::Item>,
     jitter: Jitter,
@@ -91,7 +95,7 @@ pub struct RatelimitedStream<'a, S: Stream, D: DirectStateStore> {
 }
 
 /// Conversion methods for the stream combinator.
-impl<'a, S: Stream, D: DirectStateStore> RatelimitedStream<'a, S, D> {
+impl<'a, S: Stream, D: DirectStateStore, C: clock::Clock> RatelimitedStream<'a, S, D, C> {
     /// Acquires a reference to the underlying stream that this combinator is pulling from.
     pub fn get_ref(&self) -> &S {
         &self.inner
@@ -111,11 +115,12 @@ impl<'a, S: Stream, D: DirectStateStore> RatelimitedStream<'a, S, D> {
 }
 
 /// Implements the [`futures::Stream`] combinator.
-impl<'a, S: Stream, D: DirectStateStore> Stream for RatelimitedStream<'a, S, D>
+impl<'a, S: Stream, D: DirectStateStore, C: clock::Clock> Stream for RatelimitedStream<'a, S, D, C>
 where
     S: Unpin,
     S::Item: Unpin,
     Self: Unpin,
+    C::Instant: clock::CompatibleConversion<Instant>,
 {
     type Item = S::Item;
 
@@ -138,7 +143,7 @@ where
                 }
                 State::NotReady => {
                     if let Err(negative) = self.limiter.check() {
-                        let earliest = self.jitter + negative.earliest_possible();
+                        let earliest = negative.earliest_possible_with_offset(self.jitter);
                         self.delay.reset(earliest);
                         let future = Pin::new(&mut self.delay);
                         match future.poll(cx) {
@@ -174,8 +179,8 @@ where
 }
 
 /// Pass-through implementation for [`futures::Sink`] if the Stream also implements it.
-impl<'a, Item, S: Stream + Sink<Item>, D: DirectStateStore> Sink<Item>
-    for RatelimitedStream<'a, S, D>
+impl<'a, Item, S: Stream + Sink<Item>, D: DirectStateStore, C: clock::Clock> Sink<Item>
+    for RatelimitedStream<'a, S, D, C>
 where
     S: Unpin,
     S::Item: Unpin,

--- a/src/state/keyed.rs
+++ b/src/state/keyed.rs
@@ -27,16 +27,16 @@ where
 
 #[cfg(feature = "std")]
 /// # Keyed rate limiters - default constructors
-impl<K> RateLimiter<K, DefaultKeyedStateStore<K>, clock::MonotonicClock>
+impl<K> RateLimiter<K, DefaultKeyedStateStore<K>, clock::DefaultClock>
 where
     K: Clone + Hash + Eq,
 {
     #[cfg(all(feature = "std", feature = "dashmap"))]
-    /// Construct a new keyed rate limiter backed by
+    /// Constructs a new keyed rate limiter backed by
     /// the [`DefaultKeyedStateStore`].
     pub fn keyed(quota: Quota) -> Self {
         let state = DefaultKeyedStateStore::default();
-        let clock = clock::MonotonicClock::default();
+        let clock = clock::DefaultClock::default();
         RateLimiter::new(quota, state, &clock)
     }
 
@@ -44,7 +44,7 @@ where
     /// Constructs a new keyed rate limiter explicitly backed by a [`DashMap`][dashmap::DashMap].
     pub fn dashmap(quota: Quota) -> Self {
         let state = DashMapStateStore::default();
-        let clock = clock::MonotonicClock::default();
+        let clock = clock::DefaultClock::default();
         RateLimiter::new(quota, state, &clock)
     }
 
@@ -53,13 +53,13 @@ where
     /// [`HashMap`][std::collections::HashMap].
     pub fn hashmap(quota: Quota) -> Self {
         let state = HashMapStateStore::default();
-        let clock = clock::MonotonicClock::default();
+        let clock = clock::DefaultClock::default();
         RateLimiter::new(quota, state, &clock)
     }
 }
 
 #[cfg(all(feature = "std", feature = "dashmap"))]
-impl<K> RateLimiter<K, HashMapStateStore<K>, clock::MonotonicClock>
+impl<K> RateLimiter<K, HashMapStateStore<K>, clock::DefaultClock>
 where
     K: Clone + Hash + Eq,
 {
@@ -67,7 +67,7 @@ where
     /// [`HashMap`][std::collections::HashMap].
     pub fn hashmap(quota: Quota) -> Self {
         let state = HashMapStateStore::default();
-        let clock = clock::MonotonicClock::default();
+        let clock = clock::DefaultClock::default();
         RateLimiter::new(quota, state, &clock)
     }
 }

--- a/src/state/keyed/future.rs
+++ b/src/state/keyed/future.rs
@@ -12,7 +12,7 @@ impl<K, S, C> RateLimiter<K, S, C>
 where
     K: Hash + Eq + Clone,
     S: KeyedStateStore<K>,
-    C: clock::ReasonablyRealtime
+    C: clock::ReasonablyRealtime,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/src/state/keyed/future.rs
+++ b/src/state/keyed/future.rs
@@ -1,6 +1,6 @@
 use crate::lib::*;
 use crate::{
-    clock::{self, Clock},
+    clock::{self},
     state::keyed::KeyedStateStore,
     Jitter, RateLimiter,
 };
@@ -12,8 +12,7 @@ impl<K, S, C> RateLimiter<K, S, C>
 where
     K: Hash + Eq + Clone,
     S: KeyedStateStore<K>,
-    C: Clock,
-    C::Instant: clock::CompatibleConversion<Instant>,
+    C: clock::ReasonablyRealtime
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/src/state/keyed/future.rs
+++ b/src/state/keyed/future.rs
@@ -8,10 +8,12 @@ use futures_timer::Delay;
 
 #[cfg(feature = "std")]
 /// # Keyed rate limiters - `async`/`await`
-impl<K, S> RateLimiter<K, S, clock::MonotonicClock>
+impl<K, S, C> RateLimiter<K, S, C>
 where
     K: Hash + Eq + Clone,
     S: KeyedStateStore<K>,
+    C: Clock,
+    C::Instant: clock::CompatibleConversion<Instant>,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///


### PR DESCRIPTION
This PR adds the `quanta` crate and uses it for the default clock on rate-limiters. The clocks implemented are between nicely faster (the default is 1.7x faster than `MonotonicClock`) and wayyy faster (a clock with a 10us update thread is about 2.5x faster) on my laptop.

This also updates the benchmarks to latest criterion, and fixes some style and unclear behaviors.

### TODO:
 - [x] figure out how to convert quanta's instants to `Instant`, otherwise futures won't work.