### PR TITLE
Use no_std_compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,15 +58,16 @@ more-asserts = "0.2.1"
 
 [features]
 default = ["std", "dashmap", "quanta"]
-std = ["parking_lot", "evmap", "nonzero_ext/std", "futures-timer", "futures"]
+std = ["no-std-compat/std", "parking_lot", "nonzero_ext/std", "futures-timer", "futures"]
 no_std = []
 
 [dependencies]
 nonzero_ext = {version = "0.1.5", default-features = false}
 parking_lot = {version = "0.9.0", optional = true}
-evmap = {version = "6.0.0", optional = true}
 futures-timer = {version = "2.0.0", optional = true}
 futures = {version = "0.3.1", optional = true}
 rand = "0.7.2"
 dashmap = {version = "1.2.0", optional = true}
 quanta = {version = "0.3.1", optional = true}
+no-std-compat = { version = "0.2.0", features = [ "alloc", "compat_hash" ] }
+

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -4,7 +4,15 @@
 //! to be (optionally) independent of std, and additionally
 //! allow mocking the passage of time.
 
-use crate::lib::*;
+use std::prelude::v1::*;
+
+use std::convert::TryInto;
+use std::fmt::Debug;
+use std::ops::Add;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
 
 /// A measurement from a clock.
 pub trait Reference:

--- a/src/clock/quanta.rs
+++ b/src/clock/quanta.rs
@@ -1,8 +1,11 @@
-use crate::lib::*;
+use std::prelude::v1::*;
 
 use crate::clock::{Clock, ReasonablyRealtime, Reference};
 use crate::nanos::Nanos;
 use quanta;
+use std::ops::Add;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 /// A clock using the default [`quanta::Clock`] structure.
 ///

--- a/src/clock/with_std.rs
+++ b/src/clock/with_std.rs
@@ -1,8 +1,9 @@
-use crate::lib::*;
-
 use super::{Clock, Reference};
 
+use std::prelude::v1::*;
+
 use crate::nanos::Nanos;
+use std::ops::Add;
 use std::time::{Duration, Instant, SystemTime};
 
 /// The monotonic clock implemented by [`Instant`].

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use crate::lib::*;
+use std::fmt;
 
 /// Gives additional information about the negative outcome of a batch
 /// cell decision.

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -1,7 +1,11 @@
-use crate::lib::*;
+use std::prelude::v1::*;
+
 use crate::nanos::Nanos;
 use crate::state::StateStore;
 use crate::{clock, Jitter, NegativeMultiDecision, Quota};
+use std::num::NonZeroU32;
+use std::time::Duration;
+use std::{cmp, fmt};
 
 /// A negative rate-limiting outcome.
 ///

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -5,7 +5,10 @@ use rand::distributions::uniform::{SampleBorrow, SampleUniform, UniformInt, Unif
 use rand::distributions::{Distribution, Uniform};
 use rand::{thread_rng, Rng};
 use std::ops::Add;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+#[cfg(feature = "std")]
+use std::time::Instant;
 
 /// An interval specification for deviating from the nominal wait time.
 ///

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -1,8 +1,11 @@
-use crate::lib::*;
+use std::prelude::v1::*;
+
 use crate::nanos::Nanos;
 use rand::distributions::uniform::{SampleBorrow, SampleUniform, UniformInt, UniformSampler};
 use rand::distributions::{Distribution, Uniform};
 use rand::{thread_rng, Rng};
+use std::ops::Add;
+use std::time::{Duration, Instant};
 
 /// An interval specification for deviating from the nominal wait time.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,17 +29,12 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
+extern crate no_std_compat as std;
 
 /// A facade around all the types we need from std/core crates, to
 /// avoid unnecessary cfg-conditionalization everywhere.
 mod lib {
     mod core {
-        #[cfg(not(feature = "std"))]
-        pub use core::*;
-
-        #[cfg(feature = "std")]
         pub use std::*;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,51 +31,6 @@
 
 extern crate no_std_compat as std;
 
-/// A facade around all the types we need from std/core crates, to
-/// avoid unnecessary cfg-conditionalization everywhere.
-mod lib {
-    mod core {
-        pub use std::*;
-    }
-
-    pub use self::core::borrow::Borrow;
-    pub use self::core::clone::Clone;
-    pub use self::core::cmp::{Eq, Ord, PartialEq};
-    pub use self::core::convert::TryFrom;
-    pub use self::core::convert::TryInto;
-    pub use self::core::default::Default;
-    pub use self::core::fmt::Debug;
-    pub use self::core::hash::Hash;
-    pub use self::core::marker::{Copy, PhantomData, Send, Sized, Sync};
-    pub use self::core::num::{NonZeroU128, NonZeroU32, NonZeroU64};
-    pub use self::core::ops::{Add, Div, Mul, Sub};
-    pub use self::core::sync::atomic::{AtomicU64, Ordering};
-    pub use self::core::time::Duration;
-
-    pub use self::core::cmp;
-    pub use self::core::fmt;
-
-    /// Imports that are only available on std.
-    #[cfg(feature = "std")]
-    mod std {
-        pub use std::collections::{hash_map::RandomState, HashMap};
-        pub use std::hash::BuildHasher;
-        pub use std::sync::Arc;
-        pub use std::time::Instant;
-    }
-
-    #[cfg(not(feature = "std"))]
-    mod no_std {
-        pub use alloc::sync::Arc;
-    }
-
-    #[cfg(feature = "std")]
-    pub use self::std::*;
-
-    #[cfg(not(feature = "std"))]
-    pub use self::no_std::*;
-}
-
 pub mod r#_guide;
 pub mod clock;
 mod errors;

--- a/src/nanos.rs
+++ b/src/nanos.rs
@@ -1,7 +1,12 @@
 //! A time-keeping abstraction (nanoseconds) that works for storing in an atomic integer.
 
 use crate::clock;
-use crate::lib::*;
+
+use std::convert::TryInto;
+use std::fmt;
+use std::ops::{Add, Div, Mul};
+use std::prelude::v1::*;
+use std::time::Duration;
 
 /// A number of nanoseconds from a reference point.
 ///

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -1,4 +1,7 @@
-use crate::lib::*;
+use std::prelude::v1::*;
+
+use std::num::NonZeroU32;
+use std::time::Duration;
 
 /// A rate-limiting quota.
 ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
 //! State stores for rate limiters
 
-use crate::lib::*;
+use std::prelude::v1::*;
 
 pub mod direct;
 mod in_memory;
@@ -13,6 +13,7 @@ use crate::nanos::Nanos;
 use crate::{clock, Quota};
 
 pub use direct::*;
+use std::time::Instant;
 
 /// A way for rate limiters to keep state.
 ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,6 +13,8 @@ use crate::nanos::Nanos;
 use crate::{clock, Quota};
 
 pub use direct::*;
+
+#[cfg(feature = "std")]
 use std::time::Instant;
 
 /// A way for rate limiters to keep state.

--- a/src/state/direct.rs
+++ b/src/state/direct.rs
@@ -3,8 +3,11 @@
 //! Rate limiters based on these types are constructed with
 //! [the `RateLimiter` constructors](../struct.RateLimiter.html#direct-in-memory-rate-limiters---constructors)
 
+use std::prelude::v1::*;
+
+use std::num::NonZeroU32;
+
 use crate::gcra::NotUntil;
-use crate::lib::*;
 use crate::{clock, state::InMemoryState, NegativeMultiDecision, Quota};
 
 /// The "this state store does not use keys" key type.

--- a/src/state/direct/sinks.rs
+++ b/src/state/direct/sinks.rs
@@ -1,4 +1,4 @@
-use crate::lib::*;
+use std::prelude::v1::*;
 
 use crate::{
     clock,
@@ -8,6 +8,7 @@ use crate::{
 use futures::task::{Context, Poll};
 use futures::{Future, Sink, Stream};
 use futures_timer::Delay;
+use std::marker::PhantomData;
 use std::pin::Pin;
 
 /// Allows converting a [`futures::Sink`] combinator into a rate-limited sink.  

--- a/src/state/direct/streams.rs
+++ b/src/state/direct/streams.rs
@@ -1,12 +1,14 @@
 #![cfg(feature = "std")]
 
-use crate::lib::*;
+use std::prelude::v1::*;
+
 use crate::state::{DirectStateStore, NotKeyed};
 use crate::{clock, Jitter, RateLimiter};
 use futures::task::{Context, Poll};
 use futures::{Future, Sink, Stream};
 use futures_timer::Delay;
 use std::pin::Pin;
+use std::time::Duration;
 
 /// Allows converting a [`futures::Stream`] combinator into a rate-limited stream.
 pub trait StreamRateLimitExt<'a>: Stream {

--- a/src/state/in_memory.rs
+++ b/src/state/in_memory.rs
@@ -1,7 +1,13 @@
-use crate::lib::*;
+use std::prelude::v1::*;
 
 use crate::nanos::Nanos;
 use crate::state::{NotKeyed, StateStore};
+use std::fmt;
+use std::fmt::Debug;
+use std::num::NonZeroU64;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 /// An in-memory representation of a GCRA's rate-limiting state.
 ///

--- a/src/state/keyed.rs
+++ b/src/state/keyed.rs
@@ -7,7 +7,8 @@
 //! Rate limiters based on these types are constructed with
 //! [the `RateLimiter` constructors](../struct.RateLimiter.html#keyed-rate-limiters---default-constructors)
 
-use crate::lib::*;
+use std::num::NonZeroU32;
+use std::prelude::v1::*;
 
 use crate::state::StateStore;
 use crate::{clock, NegativeMultiDecision, NotUntil, Quota, RateLimiter};
@@ -119,8 +120,10 @@ pub use hashmap::HashMapStateStore;
 
 #[cfg(all(feature = "std", feature = "dashmap"))]
 mod dashmap;
+
 #[cfg(all(feature = "std", feature = "dashmap"))]
 pub use self::dashmap::DashMapStateStore;
+use std::hash::Hash;
 
 #[cfg(feature = "std")]
 mod future;

--- a/src/state/keyed/dashmap.rs
+++ b/src/state/keyed/dashmap.rs
@@ -1,11 +1,12 @@
 #![cfg(all(feature = "std", feature = "dashmap"))]
 
-use crate::lib::*;
+use std::prelude::v1::*;
 
 use crate::nanos::Nanos;
 use crate::state::{InMemoryState, StateStore};
 use crate::{clock, Quota, RateLimiter};
 use dashmap::DashMap;
+use std::hash::Hash;
 
 /// A concurrent, thread-safe and fairly performant hashmap based on [`DashMap`].
 pub type DashMapStateStore<K> = DashMap<K, InMemoryState>;

--- a/src/state/keyed/future.rs
+++ b/src/state/keyed/future.rs
@@ -1,10 +1,12 @@
-use crate::lib::*;
+use std::prelude::v1::*;
+
 use crate::{
     clock::{self},
     state::keyed::KeyedStateStore,
     Jitter, RateLimiter,
 };
 use futures_timer::Delay;
+use std::hash::Hash;
 
 #[cfg(feature = "std")]
 /// # Keyed rate limiters - `async`/`await`

--- a/src/state/keyed/hashmap.rs
+++ b/src/state/keyed/hashmap.rs
@@ -1,11 +1,13 @@
 #![cfg(feature = "std")]
 
-use crate::lib::*;
+use std::prelude::v1::*;
 
 use crate::nanos::Nanos;
 use crate::state::{InMemoryState, StateStore};
 use crate::{clock, Quota, RateLimiter};
 use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::hash::Hash;
 
 /// A thread-safe (but not very performant) implementation of a keyed rate limiter state
 /// store using [`HashMap`].


### PR DESCRIPTION
This PR uses the `no_std_compat` crate to improve the type inference situation in IntelliJ Rust (and to reduce the amount of weird magic we have to do manually).