### PR TITLE
Use tynm to generate type names in benchmarks.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ harness = false
 
 [dev-dependencies]
 criterion = "0.3.0"
+tynm = "0.1.1"
 crossbeam = "0.7.3"
 libc = "0.2.41"
 futures = "0.3.1"

--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -6,10 +6,10 @@ use criterion::{black_box, BenchmarkId, Criterion, Throughput};
 use governor::state::keyed::{DashMapStateStore, HashMapStateStore, KeyedStateStore};
 use governor::{clock, Quota, RateLimiter};
 use nonzero_ext::*;
-use std::any::type_name;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
+use tynm::type_name;
 
 pub fn bench_all(c: &mut Criterion) {
     bench_direct(c);

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -2,8 +2,8 @@ use criterion::{black_box, BatchSize, BenchmarkId, Criterion, Throughput};
 use governor::state::keyed::{DashMapStateStore, HashMapStateStore, KeyedStateStore};
 use governor::{clock, Quota, RateLimiter};
 use nonzero_ext::*;
-use std::any::type_name;
 use std::time::Duration;
+use tynm::type_name;
 
 pub fn bench_all(c: &mut Criterion) {
     bench_direct(c);


### PR DESCRIPTION
This makes for muuuuch more readable benchmark results.