### PR TITLE
Add housekeeping operations to keyed state stores

### DIFF
--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -71,7 +71,7 @@ impl GCRA {
     }
 
     /// Computes and returns a new ratelimiter state if none exists yet.
-    fn starting_state(&self, t0: Nanos) -> Nanos {
+    pub(crate) fn starting_state(&self, t0: Nanos) -> Nanos {
         t0 + self.t
     }
 

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -71,7 +71,7 @@ impl GCRA {
     }
 
     /// Computes and returns a new ratelimiter state if none exists yet.
-    pub(crate) fn starting_state(&self, t0: Nanos) -> Nanos {
+    fn starting_state(&self, t0: Nanos) -> Nanos {
         t0 + self.t
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -85,6 +85,13 @@ where
             start,
         }
     }
+
+    /// Consumes the `RateLimiter` and returns the state store.
+    ///
+    /// This is mostly useful for debugging and testing.
+    pub fn into_state_store(self) -> S {
+        self.state
+    }
 }
 
 #[cfg(feature = "std")]

--- a/src/state/in_memory.rs
+++ b/src/state/in_memory.rs
@@ -43,6 +43,10 @@ impl InMemoryState {
         // can't see it.
         decision.map(|(result, _)| result)
     }
+
+    pub(crate) fn is_older_than(&self, nanos: Nanos) -> bool {
+        self.0.load(Ordering::Relaxed) < nanos.into()
+    }
 }
 
 /// The InMemoryState is the canonical "direct" state store.

--- a/src/state/in_memory.rs
+++ b/src/state/in_memory.rs
@@ -45,7 +45,7 @@ impl InMemoryState {
     }
 
     pub(crate) fn is_older_than(&self, nanos: Nanos) -> bool {
-        self.0.load(Ordering::Relaxed) < nanos.into()
+        self.0.load(Ordering::Relaxed) <= nanos.into()
     }
 }
 

--- a/src/state/keyed.rs
+++ b/src/state/keyed.rs
@@ -128,6 +128,11 @@ where
 pub trait ShrinkableKeyedStateStore<K: Hash>: KeyedStateStore<K> {
     /// Remove those keys with state older than `drop_below`.
     fn retain_recent(&self, drop_below: Nanos);
+
+    /// Shrinks the capacity of the state store, if possible.
+    ///
+    /// If the state store does not support shrinking, this method is a no-op.   
+    fn shrink_to_fit(&self) {}
 }
 
 /// # Keyed rate limiters - Housekeeping
@@ -154,6 +159,10 @@ where
         let drop_below = now.duration_since(self.start);
 
         self.state.retain_recent(drop_below);
+    }
+
+    pub fn shrink_to_fit(&self) {
+        self.state.shrink_to_fit();
     }
 }
 

--- a/src/state/keyed.rs
+++ b/src/state/keyed.rs
@@ -142,7 +142,7 @@ where
         // arrival time is larger than a starting state for the bucket gets to stay, everything
         // else (that's indistinguishable from a starting state) goes.
         let now = self.clock.now();
-        let drop_below = self.gcra.starting_state(now.duration_since(self.start));
+        let drop_below = now.duration_since(self.start);
 
         self.state.shrink(drop_below);
     }

--- a/src/state/keyed/dashmap.rs
+++ b/src/state/keyed/dashmap.rs
@@ -3,6 +3,7 @@
 use std::prelude::v1::*;
 
 use crate::nanos::Nanos;
+use crate::state::keyed::ShrinkableKeyedStateStore;
 use crate::state::{InMemoryState, StateStore};
 use crate::{clock, Quota, RateLimiter};
 use dashmap::DashMap;
@@ -34,5 +35,11 @@ where
     pub fn dashmap_with_clock(quota: Quota, clock: &C) -> Self {
         let state: DashMapStateStore<K> = DashMap::default();
         RateLimiter::new(quota, state, clock)
+    }
+}
+
+impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for DashMapStateStore<K> {
+    fn shrink(&self, drop_below: Nanos) {
+        self.retain(|_, v| !v.is_older_than(drop_below));
     }
 }

--- a/src/state/keyed/dashmap.rs
+++ b/src/state/keyed/dashmap.rs
@@ -39,7 +39,7 @@ where
 }
 
 impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for DashMapStateStore<K> {
-    fn shrink(&self, drop_below: Nanos) {
+    fn retain_recent(&self, drop_below: Nanos) {
         self.retain(|_, v| !v.is_older_than(drop_below));
     }
 }

--- a/src/state/keyed/hashmap.rs
+++ b/src/state/keyed/hashmap.rs
@@ -38,6 +38,10 @@ impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for HashMapStateStore<K>
     fn retain_recent(&self, drop_below: Nanos) {
         let mut map = self.lock();
         map.retain(|_, v| !v.is_older_than(drop_below));
+    }
+
+    fn shrink_to_fit(&self) {
+        let mut map = self.lock();
         map.shrink_to_fit();
     }
 }

--- a/src/state/keyed/hashmap.rs
+++ b/src/state/keyed/hashmap.rs
@@ -35,7 +35,7 @@ impl<K: Hash + Eq + Clone> StateStore for HashMapStateStore<K> {
 }
 
 impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for HashMapStateStore<K> {
-    fn shrink(&self, drop_below: Nanos) {
+    fn retain_recent(&self, drop_below: Nanos) {
         let mut map = self.lock();
         map.retain(|_, v| !v.is_older_than(drop_below));
         map.shrink_to_fit();

--- a/tests/keyed_dashmap.rs
+++ b/tests/keyed_dashmap.rs
@@ -78,22 +78,22 @@ fn expiration() {
 
     // clean up all keys that are indistinguishable from unoccupied keys:
     let lim_shrunk = make_bucket();
-    lim_shrunk.shrink();
+    lim_shrunk.retain_recent();
     assert_eq!(retained_keys(keys, lim_shrunk), keys);
 
     let lim_later = make_bucket();
     clock.advance(ms * 1200);
-    lim_later.shrink();
+    lim_later.retain_recent();
     assert_eq!(retained_keys(keys, lim_later), vec!["bar", "baz"]);
 
     let lim_later = make_bucket();
     clock.advance(ms * (1200 + 200));
-    lim_later.shrink();
+    lim_later.retain_recent();
     assert_eq!(retained_keys(keys, lim_later), vec!["baz"]);
 
     let lim_later = make_bucket();
     clock.advance(ms * (1200 + 200 + 600));
-    lim_later.shrink();
+    lim_later.retain_recent();
     assert_eq!(retained_keys(keys, lim_later), Vec::<&str>::new());
 }
 

--- a/tests/keyed_hashmap.rs
+++ b/tests/keyed_hashmap.rs
@@ -72,22 +72,22 @@ fn expiration() {
 
     // clean up all keys that are indistinguishable from unoccupied keys:
     let lim_shrunk = make_bucket();
-    lim_shrunk.shrink();
+    lim_shrunk.retain_recent();
     assert_eq!(retained_keys(lim_shrunk), keys);
 
     let lim_later = make_bucket();
     clock.advance(ms * 1200);
-    lim_later.shrink();
+    lim_later.retain_recent();
     assert_eq!(retained_keys(lim_later), vec!["bar", "baz"]);
 
     let lim_later = make_bucket();
     clock.advance(ms * (1200 + 200));
-    lim_later.shrink();
+    lim_later.retain_recent();
     assert_eq!(retained_keys(lim_later), vec!["baz"]);
 
     let lim_later = make_bucket();
     clock.advance(ms * (1200 + 200 + 600));
-    lim_later.shrink();
+    lim_later.retain_recent();
     assert_eq!(retained_keys(lim_later), Vec::<&str>::new());
 }
 

--- a/tests/keyed_hashmap.rs
+++ b/tests/keyed_hashmap.rs
@@ -1,8 +1,10 @@
+use governor::state::keyed::HashMapStateStore;
 use governor::{
     clock::{Clock, FakeRelativeClock},
     Quota, RateLimiter,
 };
 use nonzero_ext::nonzero;
+use std::hash::Hash;
 use std::time::Duration;
 
 const KEYS: &[u32] = &[1u32, 2u32];
@@ -40,6 +42,53 @@ fn rejects_too_many() {
         clock.advance(ms);
         assert_ne!(Ok(()), lb.check_key(key), "{:?}", lb);
     }
+}
+
+fn retained_keys<T: Clone + Hash + Eq + Copy + Ord>(
+    limiter: RateLimiter<T, HashMapStateStore<T>, FakeRelativeClock>,
+) -> Vec<T> {
+    let state = limiter.into_state_store();
+    let map = state.lock();
+    let mut keys: Vec<T> = map.keys().copied().collect();
+    keys.sort();
+    keys
+}
+
+#[test]
+fn expiration() {
+    let clock = FakeRelativeClock::default();
+    let ms = Duration::from_millis(1);
+
+    let make_bucket = || {
+        let lim = RateLimiter::hashmap_with_clock(Quota::per_second(nonzero!(1u32)), &clock);
+        lim.check_key(&"foo").unwrap();
+        clock.advance(ms * 200);
+        lim.check_key(&"bar").unwrap();
+        clock.advance(ms * 600);
+        lim.check_key(&"baz").unwrap();
+        lim
+    };
+    let keys = &["bar", "baz", "foo"];
+
+    // clean up all keys that are indistinguishable from unoccupied keys:
+    let lim_shrunk = make_bucket();
+    lim_shrunk.shrink();
+    assert_eq!(retained_keys(lim_shrunk), keys);
+
+    let lim_later = make_bucket();
+    clock.advance(ms * 1200);
+    lim_later.shrink();
+    assert_eq!(retained_keys(lim_later), vec!["bar", "baz"]);
+
+    let lim_later = make_bucket();
+    clock.advance(ms * (1200 + 200));
+    lim_later.shrink();
+    assert_eq!(retained_keys(lim_later), vec!["baz"]);
+
+    let lim_later = make_bucket();
+    clock.advance(ms * (1200 + 200 + 600));
+    lim_later.shrink();
+    assert_eq!(retained_keys(lim_later), Vec::<&str>::new());
 }
 
 #[test]


### PR DESCRIPTION
Since keyed state stores might grow indefinitely as new keys get used, we should allow users to evict those keys that haven't been used in a while - if their state is indistinguishable from a fresh rate-limiting state, evict it.

TODO:

- [x] add tests
- [x] maybe upgrade DashMap so we get `shrink_to_fit` - blocked by https://github.com/xacrimon/dashmap/issues/6