### PR TITLE
Use cargo deny

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo bench" }), clippy: ClippyEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }), rustfmt: RustfmtEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }), additional_matrix_entries: {"no_std_stable": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo test --no-default-features --features no_std" }), "no_std_nightly": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "nightly", install_commandline: None, commandline: "cargo +nightly test --no-default-features --features no_std" })}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
+# TemplateCIConfig { bench: BenchEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo bench" }), clippy: ClippyEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add clippy"), commandline: "cargo clippy -- -D warnings" }), rustfmt: RustfmtEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("rustup component add rustfmt"), commandline: "cargo fmt -v -- --check" }), additional_matrix_entries: {"cargo_deny": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: Some("cargo install cargo-deny"), commandline: "cargo deny check all" }), "no_std_stable": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "stable", install_commandline: None, commandline: "cargo test --no-default-features --features no_std" }), "no_std_nightly": CustomEntry(MatrixEntry { run: true, run_cron: false, version: "nightly", install_commandline: None, commandline: "cargo +nightly test --no-default-features --features no_std" })}, cache: "cargo", os: "linux", dist: "xenial", versions: ["stable", "nightly"], test_commandline: "cargo test --verbose --all", scheduled_test_branches: ["master"], test_schedule: "0 0 * * 0" }
 version: "2.1"
 
 executors:
@@ -78,6 +78,23 @@ jobs:
       - run:
           name: Bench
           command: cargo bench
+  cargo_deny:
+    parameters:
+      version:
+        type: executor
+      version_name:
+        type: string
+    executor: << parameters.version >>
+    environment:
+      CI_RUST_VERSION: << parameters.version_name >>
+    steps:
+      - checkout
+      - run:
+          name: Install
+          command: cargo install cargo-deny
+      - run:
+          name: cargo deny check all
+          command: cargo deny check all
   no_std_stable:
     parameters:
       version:
@@ -192,6 +209,10 @@ workflows:
     ]
   }
 }
+      - cargo_deny:
+          name: "cargo_deny"
+          version: stable
+          version_name: stable
       - no_std_stable:
           name: "no_std_stable"
           version: stable
@@ -207,6 +228,7 @@ workflows:
           - rustfmt
           - clippy
           - bench
+          - cargo_deny
           - no_std_stable
           - no_std_nightly
   scheduled_tests:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,12 @@ run = true
 version = "stable"
 commandline = "cargo test --no-default-features --features no_std"
 
+[package.metadata.template_ci.additional_matrix_entries.cargo_deny]
+run = true
+version = "stable"
+install_commandline = "cargo install cargo-deny"
+commandline = "cargo deny check all"
+
 [badges]
 circle-ci = { repository = "antifuchs/governor", branch = "master" }
 maintenance = { status = "actively-developed" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,46 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "MIT",
+    "ISC",  # some rand crates
+    "CC0-1.0",  # more_asserts
+]
+deny = []
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will only be approved if it is both OSI-approved *AND* FSF/Free
+# * either - The license will be approved if it is either OSI-approved *OR* FSF/Free
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF/Free
+# * fsf-only - The license will be approved if is FSF/Free *AND NOT* OSI-approved
+# * neither - The license will be denied if is FSF/Free *OR* OSI-approved
+allow-osi-fsf-free = "neither"
+confidence-threshold = 0.8
+
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+highlight = "lowest-version"
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+deny = [
+]
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+skip-tree = [
+    # criterion & proptest pull in old versions of rand & are dev-dependencies:
+    { name = "criterion", version = "=0.3.0", depth = 2 },
+    { name = "proptest", version = "0.9.4", depth = 2 },
+]


### PR DESCRIPTION
This PR adds a deny.toml, and adds a build step for checking dependencies with cargo deny.

Currently we pass with one warning (spin being unmaintained). I think I'd like to get to a place where we pass with zero - but refactoring to not depend on `spin` (via lockapi or something similar) is not easy. Later maybe.