### PR TITLE
Rename check_all -> check_n

### DIFF
--- a/src/state/direct.rs
+++ b/src/state/direct.rs
@@ -83,7 +83,7 @@ where
     /// This method diverges a little from the GCRA algorithm, using
     /// multiplication to determine the next theoretical arrival time, and so
     /// is not as fast as checking a single cell.  
-    pub fn check_all(
+    pub fn check_n(
         &self,
         n: NonZeroU32,
     ) -> Result<(), NegativeMultiDecision<NotUntil<C::Instant>>> {

--- a/src/state/direct/future.rs
+++ b/src/state/direct/future.rs
@@ -87,7 +87,7 @@ where
         n: NonZeroU32,
         jitter: Jitter,
     ) -> Result<(), InsufficientCapacity> {
-        while let Err(err) = self.check_all(n) {
+        while let Err(err) = self.check_n(n) {
             match err {
                 NegativeMultiDecision::BatchNonConforming(_, negative) => {
                     let delay = Delay::new(jitter + negative.wait_time_from(self.clock.now()));

--- a/src/state/direct/future.rs
+++ b/src/state/direct/future.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use futures_timer::Delay;
 
-/// An error that occurs when the number of cells required in `check_all`
+/// An error that occurs when the number of cells required in `check_n`
 /// exceeds the maximum capacity of the limiter.
 #[derive(Debug, Clone)]
 pub struct InsufficientCapacity(pub u32);

--- a/src/state/keyed.rs
+++ b/src/state/keyed.rs
@@ -106,7 +106,7 @@ where
     /// This method diverges a little from the GCRA algorithm, using
     /// multiplication to determine the next theoretical arrival time, and so
     /// is not as fast as checking a single cell.
-    pub fn check_key_all(
+    pub fn check_key_n(
         &self,
         key: &K,
         n: NonZeroU32,

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -44,21 +44,21 @@ fn all_1_identical_to_1() {
     let one = nonzero!(1u32);
 
     // use up our burst capacity (2 in the first second):
-    assert_eq!(Ok(()), lb.check_all(one), "Now: {:?}", clock.now());
+    assert_eq!(Ok(()), lb.check_n(one), "Now: {:?}", clock.now());
     clock.advance(ms);
-    assert_eq!(Ok(()), lb.check_all(one), "Now: {:?}", clock.now());
+    assert_eq!(Ok(()), lb.check_n(one), "Now: {:?}", clock.now());
 
     clock.advance(ms);
-    assert_ne!(Ok(()), lb.check_all(one), "Now: {:?}", clock.now());
+    assert_ne!(Ok(()), lb.check_n(one), "Now: {:?}", clock.now());
 
     // should be ok again in 1s:
     clock.advance(ms * 1000);
-    assert_eq!(Ok(()), lb.check_all(one), "Now: {:?}", clock.now());
+    assert_eq!(Ok(()), lb.check_n(one), "Now: {:?}", clock.now());
     clock.advance(ms);
-    assert_eq!(Ok(()), lb.check_all(one));
+    assert_eq!(Ok(()), lb.check_n(one));
 
     clock.advance(ms);
-    assert_ne!(Ok(()), lb.check_all(one), "{:?}", lb);
+    assert_ne!(Ok(()), lb.check_n(one), "{:?}", lb);
 }
 
 #[test]
@@ -68,40 +68,20 @@ fn never_allows_more_than_capacity_all() {
     let ms = Duration::from_millis(1);
 
     // Use up the burst capacity:
-    assert_eq!(
-        Ok(()),
-        lb.check_all(nonzero!(2u32)),
-        "Now: {:?}",
-        clock.now()
-    );
-    assert_eq!(
-        Ok(()),
-        lb.check_all(nonzero!(2u32)),
-        "Now: {:?}",
-        clock.now()
-    );
+    assert_eq!(Ok(()), lb.check_n(nonzero!(2u32)), "Now: {:?}", clock.now());
+    assert_eq!(Ok(()), lb.check_n(nonzero!(2u32)), "Now: {:?}", clock.now());
 
     clock.advance(ms);
-    assert_ne!(
-        Ok(()),
-        lb.check_all(nonzero!(2u32)),
-        "Now: {:?}",
-        clock.now()
-    );
+    assert_ne!(Ok(()), lb.check_n(nonzero!(2u32)), "Now: {:?}", clock.now());
 
     // should be ok again in 1s:
     clock.advance(ms * 1000);
-    assert_eq!(
-        Ok(()),
-        lb.check_all(nonzero!(2u32)),
-        "Now: {:?}",
-        clock.now()
-    );
+    assert_eq!(Ok(()), lb.check_n(nonzero!(2u32)), "Now: {:?}", clock.now());
     clock.advance(ms);
-    assert_eq!(Ok(()), lb.check_all(nonzero!(2u32)));
+    assert_eq!(Ok(()), lb.check_n(nonzero!(2u32)));
 
     clock.advance(ms);
-    assert_ne!(Ok(()), lb.check_all(nonzero!(2u32)), "{:?}", lb);
+    assert_ne!(Ok(()), lb.check_n(nonzero!(2u32)), "{:?}", lb);
 }
 
 #[test]
@@ -111,11 +91,11 @@ fn rejects_too_many_all() {
     let ms = Duration::from_millis(1);
 
     // Should not allow the first 15 cells on a capacity 5 bucket:
-    assert_ne!(Ok(()), lb.check_all(nonzero!(15u32)));
+    assert_ne!(Ok(()), lb.check_n(nonzero!(15u32)));
 
     // After 3 and 20 seconds, it should not allow 15 on that bucket either:
     clock.advance(ms * 3 * 1000);
-    assert_ne!(Ok(()), lb.check_all(nonzero!(15u32)));
+    assert_ne!(Ok(()), lb.check_n(nonzero!(15u32)));
 }
 
 #[test]
@@ -125,15 +105,15 @@ fn all_capacity_check_rejects_excess() {
 
     assert_eq!(
         Err(NegativeMultiDecision::InsufficientCapacity(5)),
-        lb.check_all(nonzero!(15u32))
+        lb.check_n(nonzero!(15u32))
     );
     assert_eq!(
         Err(NegativeMultiDecision::InsufficientCapacity(5)),
-        lb.check_all(nonzero!(6u32))
+        lb.check_n(nonzero!(6u32))
     );
     assert_eq!(
         Err(NegativeMultiDecision::InsufficientCapacity(5)),
-        lb.check_all(nonzero!(7u32))
+        lb.check_n(nonzero!(7u32))
     );
 }
 

--- a/tests/memory_leaks.rs
+++ b/tests/memory_leaks.rs
@@ -60,7 +60,7 @@ fn memleak_gcra_multi() {
     let leak_check = LeakCheck::new(500_000);
 
     for _i in 0..leak_check.n_iter {
-        drop(bucket.check_all(nonzero!(2u32)));
+        drop(bucket.check_n(nonzero!(2u32)));
     }
 }
 


### PR DESCRIPTION
The old name was confusing to people - it seemed like a check whether
the entire burst capacity was available. Instead, rename to check_n,
which should make the intent clear.