### PR TITLE
Do cargo deny via GitHub workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,23 +104,6 @@ jobs:
       - run:
           name: cargo test --no-default-features --features no_std
           command: cargo test --no-default-features --features no_std
-  cargo_deny:
-    parameters:
-      version:
-        type: executor
-      version_name:
-        type: string
-    executor: << parameters.version >>
-    environment:
-      CI_RUST_VERSION: << parameters.version_name >>
-    steps:
-      - checkout
-      - run:
-          name: Install
-          command: cargo install cargo-deny
-      - run:
-          name: cargo deny check all
-          command: cargo deny check all
   no_std_nightly:
     parameters:
       version:
@@ -215,10 +198,6 @@ workflows:
 }
       - no_std_stable:
           name: "no_std_stable"
-          version: stable
-          version_name: stable
-      - cargo_deny:
-          name: "cargo_deny"
           version: stable
           version_name: stable
       - no_std_nightly:

--- a/.github/workflows/cargo_deny.yml
+++ b/.github/workflows/cargo_deny.yml
@@ -1,0 +1,13 @@
+name: "Additional CI"
+# This workflow is triggered on pushes to the repository.
+on: [push]
+
+jobs:
+  cargo_deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: "cargo deny"
+      uses: EmbarkStudios/cargo-deny-action@v0
+      with:
+        command: "check all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,6 @@ run = true
 version = "stable"
 commandline = "cargo test --no-default-features --features no_std"
 
-[package.metadata.template_ci.additional_matrix_entries.cargo_deny]
-run = true
-version = "stable"
-install_commandline = "cargo install cargo-deny"
-commandline = "cargo deny check all"
-
 [badges]
 circle-ci = { repository = "antifuchs/governor", branch = "master" }
 maintenance = { status = "actively-developed" }

--- a/bors.toml
+++ b/bors.toml
@@ -3,6 +3,7 @@
 
 status = [
   "continuous_integration",
+  "cargo_deny",
 ]
 timeout_sec = 600
 delete_merged_branches = true


### PR DESCRIPTION
This is the slowest check of them all, and means that circleci blocks bors merges for much longer than it should. Let's split it into a separate (also free) CI system.