### PR TITLE
Replace spin crate with parking_lot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@
   must now use `MonotonicClock` instead of `MonotonicClock()`.
 * The `clock::ReasonablyRealtime` trait got simplified and no longer
   has any required methods to implement, only one default method.
+* Replaced the `spin` crate with `parking_lot` for `no_std` contexts.
 
 ### Contributors
 
 * [@Restioson](https://github.com/Restioson)
+* [@korrat](https://github.com/korrat)
 
 ## [[0.2.0](https://docs.rs/governor/0.2.0/governor/)] - 2020-03-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,16 +50,15 @@ more-asserts = "0.2.1"
 
 [features]
 default = ["std", "dashmap", "quanta"]
-std = ["no-std-compat/std", "parking_lot", "nonzero_ext/std", "futures-timer", "futures"]
+std = ["no-std-compat/std", "nonzero_ext/std", "futures-timer", "futures"]
 no_std = []
 
 [dependencies]
 nonzero_ext = {version = "0.2.0", default-features = false}
-parking_lot = {version = "0.10.0", optional = true}
+parking_lot = "0.10.0"
 futures-timer = {version = "3.0.2", optional = true}
 futures = {version = "0.3.1", optional = true}
 rand = "0.7.2"
 dashmap = {version = "3.1.0", optional = true}
 quanta = {version = "0.4.1", optional = true}
 no-std-compat = { version = "0.4.0", features = [ "alloc", "compat_hash" ] }
-spin = "0.5.2"

--- a/src/state/keyed/hashmap.rs
+++ b/src/state/keyed/hashmap.rs
@@ -7,10 +7,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 use crate::state::keyed::ShrinkableKeyedStateStore;
-#[cfg(feature = "std")]
 use parking_lot::Mutex;
-#[cfg(not(feature = "std"))]
-use spin::Mutex;
 
 /// A thread-safe (but not very performant) implementation of a keyed rate limiter state
 /// store using [`HashMap`].


### PR DESCRIPTION
The spin crate is no longer actively maintained according to its [Readme](https://github.com/mvdnes/spin-rs/commit/7516c80). Therefore, the [Rust Security Advisory Database](https://rustsec.org/advisories/RUSTSEC-2019-0031) recommends replacing it with an alternative crate. This patch uses the parking_lot crate which is already used in `std` environments.