### PR TITLE
Updates dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,12 +40,12 @@ name = "governor_criterion_benches"
 harness = false
 
 [dev-dependencies]
-criterion = "0.3.0"
-tynm = "0.1.1"
+criterion = "0.3.2"
+tynm = "0.1.4"
 crossbeam = "0.7.3"
-libc = "0.2.41"
-futures = "0.3.1"
-proptest = "0.9.4"
+libc = "0.2.70"
+futures = "0.3.5"
+proptest = "0.9.6"
 more-asserts = "0.2.1"
 
 [features]
@@ -55,11 +55,11 @@ jitter = ["rand"]
 no_std = []
 
 [dependencies]
-nonzero_ext = {version = "0.2.0", default-features = false}
-parking_lot = "0.10.0"
-futures-timer = {version = "3.0.2", optional = true}
-futures = {version = "0.3.1", optional = true}
-rand = { version = "0.7.2", optional = true }
-dashmap = {version = "3.1.0", optional = true}
-quanta = {version = "0.4.1", optional = true}
+nonzero_ext = { version = "0.2.0", default-features = false }
+parking_lot = "0.10.2"
+futures-timer = { version = "3.0.2", optional = true }
+futures = { version = "0.3.5", optional = true }
+rand = { version = "0.7.3", optional = true }
+dashmap = { version = "3.11.1", optional = true }
+quanta = { version = "0.4.1", optional = true }
 no-std-compat = { version = "0.4.0", features = [ "alloc", "compat_hash" ] }


### PR DESCRIPTION
Updates the following dependency versions.

```
parking_lot  v0.10.0 -> v0.10.2
proptest      v0.9.4 -> v0.9.6
criterion     v0.3.0 -> v0.3.2
futures       v0.3.1 -> v0.3.5
futures       v0.3.1 -> v0.3.5
rand          v0.7.2 -> v0.7.3
libc 1        v0.2.4 -> v0.2.70
dashmap       v3.1.0 -> v3.11.1
quanta        v0.4.1 -> v0.5.2
tynm          v0.1.1 -> v0.1.4
```

Notably, updating `quanta` from `0.4` to `0.5` runs into https://github.com/metrics-rs/quanta/issues/16, where initializing a `quanta::Clock` takes 1 second, as calibration is done. That's why some tests require `Instant.now()` to be moved after instantiating the `RateLimiter`.
