### PR TITLE
quanta: 0.5.2 + calibrate it only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
 * The `clock::ReasonablyRealtime` trait got simplified and no longer
   has any required methods to implement, only one default method.
 * Replaced the `spin` crate with `parking_lot` for `no_std` contexts.
+* The quanta clock (which is the default) now has a mandatory one-time
+  1 second calibration step. The function
+  `governor::clock::calibrate_quanta_clock` can be used to perform
+  that calibration at startup, otherwise the clock is calibrated the
+  first time that a rate limiter is constructed.
+
+### Added
+
+* New feature `enable_quanta` (on by default): This replaces the
+  `quanta` feature.
 
 ### Contributors
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ proptest = "0.9.4"
 more-asserts = "0.2.1"
 
 [features]
-default = ["std", "dashmap", "quanta"]
+default = ["std", "dashmap", "enable-quanta"]
+enable-quanta = ["quanta", "once_cell"]
 std = ["no-std-compat/std", "nonzero_ext/std", "futures-timer", "futures"]
 no_std = []
 
@@ -61,4 +62,5 @@ futures = {version = "0.3.1", optional = true}
 rand = "0.7.2"
 dashmap = {version = "3.1.0", optional = true}
 quanta = {version = "0.4.1", optional = true}
+once_cell = {version = "1.4.0", optional = true}
 no-std-compat = { version = "0.4.0", features = [ "alloc", "compat_hash" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,6 @@ futures-timer = {version = "3.0.2", optional = true}
 futures = {version = "0.3.1", optional = true}
 rand = "0.7.2"
 dashmap = {version = "3.1.0", optional = true}
-quanta = {version = "0.4.1", optional = true}
+quanta = {version = "0.5.2", optional = true}
 once_cell = {version = "1.4.0", optional = true}
 no-std-compat = { version = "0.4.0", features = [ "alloc", "compat_hash" ] }

--- a/tests/sinks.rs
+++ b/tests/sinks.rs
@@ -2,13 +2,14 @@
 
 use futures::executor::block_on;
 use futures::SinkExt;
-use governor::{prelude::*, Quota, RateLimiter};
+use governor::{clock, prelude::*, Quota, RateLimiter};
 use nonzero_ext::*;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[test]
 fn sink() {
+    clock::calibrate_quanta_clock();
     let i = Instant::now();
     let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
     let mut sink = Vec::new().ratelimit_sink(&lim);

--- a/tests/streams.rs
+++ b/tests/streams.rs
@@ -2,13 +2,14 @@
 
 use futures::executor::block_on;
 use futures::{stream, StreamExt};
-use governor::{prelude::*, Quota, RateLimiter};
+use governor::{clock, prelude::*, Quota, RateLimiter};
 use nonzero_ext::*;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[test]
 fn stream() {
+    clock::calibrate_quanta_clock();
     let i = Instant::now();
     let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
     let mut stream = stream::repeat(()).ratelimit_stream(&lim);


### PR DESCRIPTION
This PR shows the work we'd need to get a quanta clock that comes with a mandatory calibration step (which takes 1s):

* Introduces a new feature `enable_quanta` so that we can pull in more than one crate
* Adds a `calibrate_quanta_clock` function
* calibrates only once using once_cell's sync Lazy.

This still fails tests because some use real clocks & those sometimes run in different processes, and so take 1s to calibrate each. That's not ideal & if quanta keeps doing this, we should probably move off of it as a default time source.

- [ ] Leave this open until https://github.com/metrics-rs/quanta/issues/16 has a resolution.