### PR TITLE
Implement `len` and `is_empty` on shrinkable keyed rate limiters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+* The `ShrinkableKeyedStateStore` trait now has required `len` and
+  `is_empty` methods, which are also made available on any
+  `RateLimiter` that uses a shrinkable (Hashmap / Dashmap backed)
+  state store. Thanks to [@lytefast](https://github.com/lytefast) for
+  the idea and [pull request](https://github.com/antifuchs/ratelimit_meter/pull/38)
+  on `ratelimit_meter`!
+
 ### Changed
 
 * The `MonotonicClock` and `SystemClock` struct definitions now are
@@ -17,6 +26,7 @@
 
 * [@Restioson](https://github.com/Restioson)
 * [@korrat](https://github.com/korrat)
+* [@lytefast](https://github.com/lytefast)
 
 ## [[0.2.0](https://docs.rs/governor/0.2.0/governor/)] - 2020-03-01
 

--- a/src/state/keyed/dashmap.rs
+++ b/src/state/keyed/dashmap.rs
@@ -51,4 +51,12 @@ impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for DashMapStateStore<K>
     fn shrink_to_fit(&self) {
         self.shrink_to_fit();
     }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
 }

--- a/src/state/keyed/hashmap.rs
+++ b/src/state/keyed/hashmap.rs
@@ -46,6 +46,15 @@ impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for HashMapStateStore<K>
         let mut map = self.lock();
         map.shrink_to_fit();
     }
+
+    fn len(&self) -> usize {
+        let map = self.lock();
+        (*map).len()
+    }
+    fn is_empty(&self) -> bool {
+        let map = self.lock();
+        (*map).is_empty()
+    }
 }
 
 /// # Keyed rate limiters - [`HashMap`]-backed

--- a/tests/keyed_dashmap.rs
+++ b/tests/keyed_dashmap.rs
@@ -121,3 +121,22 @@ fn actual_threadsafety() {
         assert_eq!(Ok(()), lim.check_key(key));
     }
 }
+
+#[test]
+fn dashmap_length() {
+    let lim = RateLimiter::dashmap(Quota::per_second(nonzero!(1u32)));
+    assert_eq!(lim.len(), 0);
+    assert!(lim.is_empty(), true);
+
+    lim.check_key(&"foo").unwrap();
+    assert_eq!(lim.len(), 1);
+    assert!(!lim.is_empty(),);
+
+    lim.check_key(&"bar").unwrap();
+    assert_eq!(lim.len(), 2);
+    assert!(!lim.is_empty());
+
+    lim.check_key(&"baz").unwrap();
+    assert_eq!(lim.len(), 3);
+    assert!(!lim.is_empty());
+}

--- a/tests/keyed_hashmap.rs
+++ b/tests/keyed_hashmap.rs
@@ -115,3 +115,22 @@ fn actual_threadsafety() {
         assert_eq!(Ok(()), lim.check_key(key));
     }
 }
+
+#[test]
+fn hashmap_length() {
+    let lim = RateLimiter::hashmap(Quota::per_second(nonzero!(1u32)));
+    assert_eq!(lim.len(), 0);
+    assert!(lim.is_empty(), true);
+
+    lim.check_key(&"foo").unwrap();
+    assert_eq!(lim.len(), 1);
+    assert!(!lim.is_empty(),);
+
+    lim.check_key(&"bar").unwrap();
+    assert_eq!(lim.len(), 2);
+    assert!(!lim.is_empty());
+
+    lim.check_key(&"baz").unwrap();
+    assert_eq!(lim.len(), 3);
+    assert!(!lim.is_empty());
+}


### PR DESCRIPTION
This allows users to measure whether the state store they're using needs shrinking / expiration at all.

As this changes a public trait incompatibly, this will need a "big" version number bump on release.