### PR TITLE
Bump cargo-deny action to v1

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: "cargo deny"
-      uses: EmbarkStudios/cargo-deny-action@v1.0.1 # Effectively cargo-deny 0.6.7
+      uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: "check all"
   cargo_clippy:


### PR DESCRIPTION
This should fix the github action failure (which fails the same way as https://github.com/EmbarkStudios/cargo-deny-action/issues/23, except we were using `v1.0.1` instead of `v0`)