### PR TITLE
Use Arc::clone instead of limiter.clone()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* Updated the [`Arc` guide section](https://docs.rs/governor/0.3.3/governor/_guide/index.html#wrapping-the-limiter-in-an-arc) to use `Arc::clone()` instead of `limiter.clone()`.
+
+### Contributors
+* [@izik1](https://github.com/izik1)
+
 ## [[0.3.2](https://docs.rs/governor/0.3.2/governor/)] - 2021-01-28
 
 ## [[0.3.1](https://docs.rs/governor/0.3.1/governor/)] - 2020-07-26

--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -34,7 +34,7 @@ fn bench_direct(c: &mut Criterion) {
             let mut children = vec![];
             let start = Instant::now();
             for _i in 0..THREADS {
-                let lim = lim.clone();
+                let lim = Arc::clone(&lim);
                 children.push(thread::spawn(move || {
                     for _i in 0..iters {
                         black_box(lim.check().is_ok());
@@ -71,7 +71,7 @@ fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mu
             let mut children = vec![];
             let start = Instant::now();
             for _i in 0..THREADS {
-                let lim = lim.clone();
+                let lim = Arc::clone(&lim);
                 children.push(thread::spawn(move || {
                     for _i in 0..iters {
                         black_box(lim.check_key(&1u32).is_ok());

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -87,7 +87,7 @@ fn multiple() {
     let mut children = vec![];
 
     for _i in 0..20 {
-        let lim = lim.clone();
+        let lim = Arc::clone(&lim);
         children.push(thread::spawn(move || {
             block_on(lim.until_ready());
         }));
@@ -113,7 +113,7 @@ fn multiple_keyed() {
     let mut children = vec![];
 
     for _i in 0..20 {
-        let lim = lim.clone();
+        let lim = Arc::clone(&lim);
         children.push(thread::spawn(move || {
             block_on(lim.until_key_ready(&1u32));
         }));

--- a/tests/memory_leaks.rs
+++ b/tests/memory_leaks.rs
@@ -72,7 +72,7 @@ fn memleak_gcra_threaded() {
     let leak_check = LeakCheck::new(5_000);
 
     for _i in 0..leak_check.n_iter {
-        let bucket = bucket.clone();
+        let bucket = Arc::clone(&bucket);
         thread::spawn(move || {
             assert_eq!(Ok(()), bucket.check());
         })


### PR DESCRIPTION
It's much easier to explain what's going on using the explicit `Arc::clone()` way, so let's do that. This PR adjusts the guide & all test using `.clone()`.

Fixes #63.