### PR TITLE
Introduce optional middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+* You can now alter&expand the information returned from a rate
+  limiter by attaching middleware to it using
+  `.with_middleware::<YourClass>()` at construction time.
+
+  This is an incompatible change, as the type signature of RateLimiter
+  gained an additional generic parameter. See the [pull
+  request](https://github.com/antifuchs/governor/pull/67) and
+  [issue #66](https://github.com/antifuchs/governor/issues/66) for
+  details.
+
 ### Changed
 
 * Updated the [`Arc` guide section](https://docs.rs/governor/0.3.3/governor/_guide/index.html#wrapping-the-limiter-in-an-arc) to use `Arc::clone()` instead of `limiter.clone()`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam = "0.8.0"
 libc = "0.2.70"
 futures = "0.3.5"
 proptest = "1.0.0"
-more-asserts = "0.2.1"
+all_asserts = "2.2.0"
 
 [features]
 default = ["std", "dashmap", "jitter", "quanta"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,11 @@ maintenance = { status = "actively-developed" }
 name = "governor_criterion_benches"
 harness = false
 
+[lib]
+bench = false
+
 [dev-dependencies]
-criterion = "0.3.2"
+criterion = {version = "0.3.2", features = ["html_reports"]}
 tynm = "0.1.4"
 crossbeam = "0.8.0"
 libc = "0.2.70"

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -43,8 +43,12 @@ fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mu
             let state: M = Default::default();
             let clock = clock::FakeRelativeClock::default();
             let step = Duration::from_millis(20);
-            let rl: RateLimiter<_, _, _, NoOpMiddleware> =
-                RateLimiter::new(Quota::per_second(nonzero!(50u32)), state, &clock);
+            let rl: RateLimiter<
+                _,
+                _,
+                _,
+                NoOpMiddleware<<clock::FakeRelativeClock as clock::Clock>::Instant>,
+            > = RateLimiter::new(Quota::per_second(nonzero!(50u32)), state, &clock);
             b.iter_batched(
                 || {
                     clock.advance(step);

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -1,6 +1,9 @@
 use criterion::{black_box, BatchSize, BenchmarkId, Criterion, Throughput};
-use governor::state::keyed::{DashMapStateStore, HashMapStateStore, KeyedStateStore};
 use governor::{clock, Quota, RateLimiter};
+use governor::{
+    middleware::NoOpMiddleware,
+    state::keyed::{DashMapStateStore, HashMapStateStore, KeyedStateStore},
+};
 use nonzero_ext::*;
 use std::time::Duration;
 use tynm::type_name;
@@ -40,7 +43,8 @@ fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mu
             let state: M = Default::default();
             let clock = clock::FakeRelativeClock::default();
             let step = Duration::from_millis(20);
-            let rl = RateLimiter::new(Quota::per_second(nonzero!(50u32)), state, &clock);
+            let rl: RateLimiter<_, _, _, NoOpMiddleware> =
+                RateLimiter::new(Quota::per_second(nonzero!(50u32)), state, &clock);
             b.iter_batched(
                 || {
                     clock.advance(step);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 /// Gives additional information about the negative outcome of a batch
 /// cell decision.
 ///
@@ -14,7 +12,7 @@ use std::fmt;
 ///     limite parameters can never accomodate the number of cells
 ///     queried for.
 #[derive(Debug, PartialEq)]
-pub enum NegativeMultiDecision<E: fmt::Display> {
+pub enum NegativeMultiDecision<E> {
     /// A batch of cells (the first argument) is non-conforming and
     /// can not be let through at this time. The second argument gives
     /// information about when that batch of cells might be let

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -41,6 +41,11 @@ impl<'a, P: clock::Reference, MW: RateLimitingMiddleware> NotUntil<'a, P, MW> {
         earliest.duration_since(earliest.min(from)).into()
     }
 
+    /// Returns the rate limiting [`Quota`] used to reach the decision.
+    pub fn quota(&self) -> Quota {
+        Quota::from_gcra_parameters(self.limiter.t, self.limiter.tau)
+    }
+
     #[cfg(feature = "std")] // not used unless we use Instant-compatible clocks.
     pub(crate) fn earliest_possible_with_offset(&self, jitter: Jitter) -> P {
         let tat = jitter + self.tat;

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -80,7 +80,7 @@ impl Gcra {
     pub(crate) fn new(quota: Quota) -> Self {
         let tau: Nanos = (quota.replenish_1_per * quota.max_burst.get()).into();
         let t: Nanos = quota.replenish_1_per.into();
-        Gcra { tau, t }
+        Gcra { t, tau }
     }
 
     /// Computes and returns a new ratelimiter state if none exists yet.
@@ -161,9 +161,9 @@ impl Gcra {
     }
 }
 
-impl Into<StateSnapshot> for (&Gcra, Nanos) {
-    fn into(self) -> StateSnapshot {
-        StateSnapshot::new(self.0.t, self.0.tau, self.1)
+impl From<(&Gcra, Nanos)> for StateSnapshot {
+    fn from(pair: (&Gcra, Nanos)) -> Self {
+        StateSnapshot::new(pair.0.t, pair.0.tau, pair.1)
     }
 }
 

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -130,7 +130,7 @@ where
         n: NonZeroU32,
         state: &impl StateStore<Key = K>,
         t0: P,
-    ) -> Result<(), NegativeMultiDecision<NotUntil<P, MW>>> {
+    ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<NotUntil<P, MW>>> {
         let t0 = t0.duration_since(start);
         let tau = self.tau;
         let t = self.t;
@@ -147,16 +147,16 @@ where
             let tat = tat.unwrap_or_else(|| self.starting_state(t0));
             let earliest_time = (tat + additional_weight).saturating_sub(tau);
             if t0 < earliest_time {
-                Err(NegativeMultiDecision::BatchNonConforming(
-                    n.get(),
-                    NotUntil {
-                        limiter: self,
-                        tat: earliest_time,
-                        start,
-                    },
-                ))
+                let nope = NotUntil {
+                    limiter: self,
+                    tat: earliest_time,
+                    start,
+                };
+                MW::disallow(key, start, &nope);
+                Err(NegativeMultiDecision::BatchNonConforming(n.get(), nope))
             } else {
-                Ok(((), cmp::max(tat, t0) + t + additional_weight))
+                let next = cmp::max(tat, t0) + t + additional_weight;
+                Ok((MW::allow(key, start, next), next))
             }
         })
     }

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -20,6 +20,7 @@ pub struct NotUntil<P: clock::Reference> {
 
 impl<'a, P: clock::Reference> NotUntil<P> {
     /// Create a `NotUntil` as a negative rate-limiting result.
+    #[inline]
     pub(crate) fn new(state: StateSnapshot, start: P) -> Self {
         Self { state, start }
     }
@@ -27,6 +28,7 @@ impl<'a, P: clock::Reference> NotUntil<P> {
     /// Returns the earliest time at which a decision could be
     /// conforming (excluding conforming decisions made by the Decider
     /// that are made in the meantime).
+    #[inline]
     pub fn earliest_possible(&self) -> P {
         let tat: Nanos = self.state.tat;
         self.start + tat
@@ -38,23 +40,27 @@ impl<'a, P: clock::Reference> NotUntil<P> {
     ///
     /// If the time of the next expected positive result is in the past,
     /// `wait_time_from` returns a zero `Duration`.
+    #[inline]
     pub fn wait_time_from(&self, from: P) -> Duration {
         let earliest = self.earliest_possible();
         earliest.duration_since(earliest.min(from)).into()
     }
 
     /// Returns the rate limiting [`Quota`] used to reach the decision.
+    #[inline]
     pub fn quota(&self) -> Quota {
         self.state.quota()
     }
 
     #[cfg(feature = "std")] // not used unless we use Instant-compatible clocks.
+    #[inline]
     pub(crate) fn earliest_possible_with_offset(&self, jitter: Jitter) -> P {
         let tat = jitter + self.state.tat;
         self.start + tat
     }
 
     #[cfg(feature = "std")] // not used unless we use Instant-compatible clocks.
+    #[inline]
     pub(crate) fn wait_time_with_offset(&self, from: P, jitter: Jitter) -> Duration {
         let earliest = self.earliest_possible_with_offset(jitter);
         earliest.duration_since(earliest.min(from)).into()
@@ -162,6 +168,7 @@ impl Gcra {
 }
 
 impl From<(&Gcra, Nanos)> for StateSnapshot {
+    #[inline]
     fn from(pair: (&Gcra, Nanos)) -> Self {
         StateSnapshot::new(pair.0.t, pair.0.tau, pair.1)
     }

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -118,16 +118,12 @@ where
                     tat: earliest_time,
                     start,
                 };
-                MW::disallow(
-                    key,
-                    StateSnapshot::new(start, self.t, self.tau, None),
-                    &nope,
-                );
+                MW::disallow(key, StateSnapshot::new(self.t, self.tau, None), &nope);
                 Err(nope)
             } else {
                 let next = cmp::max(tat, t0) + t;
                 Ok((
-                    MW::allow::<K, P>(key, StateSnapshot::new(start, self.t, self.tau, Some(next))),
+                    MW::allow(key, StateSnapshot::new(self.t, self.tau, Some(next))),
                     next,
                 ))
             }
@@ -164,16 +160,12 @@ where
                     tat: earliest_time,
                     start,
                 };
-                MW::disallow(
-                    key,
-                    StateSnapshot::new(start, self.t, self.tau, None),
-                    &nope,
-                );
+                MW::disallow(key, StateSnapshot::new(self.t, self.tau, None), &nope);
                 Err(NegativeMultiDecision::BatchNonConforming(n.get(), nope))
             } else {
                 let next = cmp::max(tat, t0) + t + additional_weight;
                 Ok((
-                    MW::allow::<K, P>(key, StateSnapshot::new(start, self.t, self.tau, Some(next))),
+                    MW::allow(key, StateSnapshot::new(self.t, self.tau, Some(next))),
                     next,
                 ))
             }

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -162,6 +162,16 @@ where
     }
 }
 
+impl<MW: RateLimitingMiddleware> Gcra<MW> {
+    pub(crate) fn with_middleware<MW2: RateLimitingMiddleware>(self) -> Gcra<MW2> {
+        Gcra {
+            t: self.t,
+            tau: self.tau,
+            middleware: PhantomData,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -170,16 +170,17 @@ impl From<(&Gcra, Nanos)> for StateSnapshot {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{Quota, RateLimiter};
-    use clock::FakeRelativeClock;
-    use nonzero_ext::nonzero;
+    use crate::Quota;
     use std::num::NonZeroU32;
 
     use proptest::prelude::*;
 
     /// Exercise derives and convenience impls on Gcra to make coverage happy
+    #[cfg(feature = "std")]
     #[test]
     fn gcra_derives() {
+        use nonzero_ext::nonzero;
+
         let g = Gcra::new(Quota::per_second(nonzero!(1u32)));
         let g2 = Gcra::new(Quota::per_second(nonzero!(2u32)));
         assert_eq!(g, g);
@@ -188,8 +189,13 @@ mod test {
     }
 
     /// Exercise derives and convenience impls on NotUntil to make coverage happy
+    #[cfg(feature = "std")]
     #[test]
     fn notuntil_impls() {
+        use crate::RateLimiter;
+        use clock::FakeRelativeClock;
+        use nonzero_ext::nonzero;
+
         let clock = FakeRelativeClock::default();
         let lb = RateLimiter::direct_with_clock(Quota::per_second(nonzero!(1u32)), &clock);
         assert!(lb.check().is_ok());

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -65,10 +65,10 @@ pub(crate) struct Gcra<MW = NoOpMiddleware>
 where
     MW: RateLimitingMiddleware,
 {
-    // The "weight" of a single packet in units of time.
+    /// The "weight" of a single packet in units of time.
     t: Nanos,
 
-    // The "capacity" of the bucket.
+    /// The "burst capacity" of the bucket.
     tau: Nanos,
 
     middleware: PhantomData<MW>,
@@ -117,7 +117,7 @@ where
                 Err(nope)
             } else {
                 let next = cmp::max(tat, t0) + t;
-                Ok((MW::allow(key, start, next), next))
+                Ok((MW::allow(key, || start + next), next))
             }
         })
     }
@@ -156,7 +156,7 @@ where
                 Err(NegativeMultiDecision::BatchNonConforming(n.get(), nope))
             } else {
                 let next = cmp::max(tat, t0) + t + additional_weight;
-                Ok((MW::allow(key, start, next), next))
+                Ok((MW::allow(key, || start + next), next))
             }
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@ pub use gcra::NotUntil;
 pub use jitter::Jitter;
 #[cfg(all(not(feature = "std"), feature = "jitter"))]
 pub(crate) use jitter::Jitter;
+#[doc(inline)]
+pub use middleware::RateLimitingMiddleware;
 pub use quota::Quota;
 #[doc(inline)]
 pub use state::RateLimiter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub mod clock;
 mod errors;
 mod gcra;
 mod jitter;
-mod middleware;
+pub mod middleware;
 mod nanos;
 mod quota;
 pub mod state;
@@ -52,8 +52,6 @@ pub use gcra::NotUntil;
 pub use jitter::Jitter;
 #[cfg(all(not(feature = "std"), feature = "jitter"))]
 pub(crate) use jitter::Jitter;
-#[doc(inline)]
-pub use middleware::RateLimitingMiddleware;
 pub use quota::Quota;
 #[doc(inline)]
 pub use state::RateLimiter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod clock;
 mod errors;
 mod gcra;
 mod jitter;
+mod middleware;
 mod nanos;
 mod quota;
 pub mod state;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -132,7 +132,7 @@ pub trait RateLimitingMiddleware<P: clock::Reference>: fmt::Debug {
     /// By default, rate limiters return `Err(NotUntil{...})`, which
     /// allows interrogating the minimum amount of time to wait until
     /// a client can expect to have a cell allowed again.
-    type NegativeOutcome: Sized + fmt::Display;
+    type NegativeOutcome: Sized;
 
     /// Called when a positive rate-limiting decision is made.
     ///

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -158,9 +158,7 @@ pub trait RateLimitingMiddleware<P: clock::Reference>: fmt::Debug {
         key: &K,
         limiter: impl Into<StateSnapshot>,
         start_time: P,
-    ) -> Self::NegativeOutcome
-    where
-        Self: Sized;
+    ) -> Self::NegativeOutcome;
 }
 
 #[derive(Debug)]
@@ -186,10 +184,7 @@ impl<P: clock::Reference> RateLimitingMiddleware<P> for NoOpMiddleware<P> {
         _key: &K,
         state: impl Into<StateSnapshot>,
         start_time: P,
-    ) -> Self::NegativeOutcome
-    where
-        Self: Sized,
-    {
+    ) -> Self::NegativeOutcome {
         NotUntil::new(state.into(), start_time)
     }
 }
@@ -213,10 +208,7 @@ impl<P: clock::Reference> RateLimitingMiddleware<P> for StateInformationMiddlewa
         _key: &K,
         state: impl Into<StateSnapshot>,
         start_time: P,
-    ) -> Self::NegativeOutcome
-    where
-        Self: Sized,
-    {
+    ) -> Self::NegativeOutcome {
         NotUntil::new(state.into(), start_time)
     }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,6 +1,61 @@
+//! Additional and customizable behavior for rate limiters.
+//!
+//! Rate-limiting middleware follows the principle that basic
+//! rate-limiting should be very cheap, and unless users desire more
+//! behavior, they should not pay any extra price.
+//!
+//! However, those who wish to get additional features should find the
+//! means to do so. The middleware module attempts to make this
+//! possible.
+// TODO: More docs.
+//
 use core::fmt;
 
-use crate::{clock, NotUntil, Quota};
+use crate::{clock, nanos::Nanos, NotUntil, Quota};
+
+/// Information about the rate-limiting state used to reach a decision.
+#[derive(Clone, PartialEq, Debug)]
+pub struct StateSnapshot<P: clock::Reference> {
+    start: P,
+
+    /// The "weight" of a single packet in units of time.
+    t: Nanos,
+
+    /// The "burst capacity" of the bucket.
+    tau: Nanos,
+
+    /// The next time a cell is expected to arrive
+    tat: Option<Nanos>,
+}
+
+impl<P: clock::Reference> StateSnapshot<P> {
+    #[inline]
+    pub(crate) fn new(start: P, t: Nanos, tau: Nanos, tat: Option<Nanos>) -> Self {
+        Self { start, t, tau, tat }
+    }
+
+    /// Returns the quota used to make the rate limiting decision.
+    pub fn quota(&self) -> Quota {
+        Quota::from_gcra_parameters(self.t, self.tau)
+    }
+
+    /// Returns the number of cells that can be let through in
+    /// addition to a (possible) positive outcome.
+    ///
+    /// Returns None if the rate limiting decision was not positive.
+    pub fn remaining_burst_capacity(&self) -> Option<u64> {
+        self.tat.map(|tat| {
+            // at this point we know that we're `tat` nanos after the
+            // earliest arrival time, and so are using up some "burst
+            // capacity".
+            //
+            // As one cell has already been used by the positive
+            // decision, we're relying on the "round down" behavior of
+            // unsigned integer division.
+            tat / self.t
+        })
+    }
+}
 
 /// Implements additional behavior when rate-limiting decisions are made.
 pub trait RateLimitingMiddleware: fmt::Debug + PartialEq {
@@ -15,16 +70,17 @@ pub trait RateLimitingMiddleware: fmt::Debug + PartialEq {
     /// As arguments, it takes a `key` (the item we were testing for)
     /// and a `when` closure that, if called, returns the time at
     /// which the next cell is expected.
-    fn allow<K, P, F, Q>(key: &K, when: F, quota: Q) -> Self::PositiveOutcome
+    fn allow<K, P>(key: &K, state: StateSnapshot<P>) -> Self::PositiveOutcome
     where
-        P: clock::Reference,
-        F: Fn() -> P,
-        Q: Fn() -> Quota;
+        P: clock::Reference;
 
     /// Called when a negative rate-limiting decision is made (the
     /// "not allowed but OK" case).
-    fn disallow<K, P: clock::Reference>(key: &K, decision_at: P, not_until: &NotUntil<P, Self>)
-    where
+    fn disallow<K, P: clock::Reference>(
+        key: &K,
+        state: StateSnapshot<P>,
+        not_until: &NotUntil<P, Self>,
+    ) where
         Self: Sized;
 }
 
@@ -39,18 +95,19 @@ impl RateLimitingMiddleware for NoOpMiddleware {
 
     #[inline]
     /// Returns `()` and has no side-effects.
-    fn allow<K, P, F, Q>(_key: &K, _when: F, _quota: Q) -> Self::PositiveOutcome
+    fn allow<K, P>(_key: &K, _state: StateSnapshot<P>) -> Self::PositiveOutcome
     where
         P: clock::Reference,
-        F: Fn() -> P,
-        Q: Fn() -> Quota,
     {
     }
 
     #[inline]
     /// Does nothing.
-    fn disallow<K, P: clock::Reference>(_key: &K, _decision_at: P, _not_until: &NotUntil<P, Self>)
-    where
+    fn disallow<K, P: clock::Reference>(
+        _key: &K,
+        _state: StateSnapshot<P>,
+        _not_until: &NotUntil<P, Self>,
+    ) where
         Self: Sized,
     {
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{clock, NotUntil};
+use crate::{clock, NotUntil, Quota};
 
 /// Implements additional behavior when rate-limiting decisions are made.
 pub trait RateLimitingMiddleware: fmt::Debug + PartialEq {
@@ -15,10 +15,11 @@ pub trait RateLimitingMiddleware: fmt::Debug + PartialEq {
     /// As arguments, it takes a `key` (the item we were testing for)
     /// and a `when` closure that, if called, returns the time at
     /// which the next cell is expected.
-    fn allow<K, P, F>(key: &K, when: F) -> Self::PositiveOutcome
+    fn allow<K, P, F, Q>(key: &K, when: F, quota: Q) -> Self::PositiveOutcome
     where
         P: clock::Reference,
-        F: Fn() -> P;
+        F: Fn() -> P,
+        Q: Fn() -> Quota;
 
     /// Called when a negative rate-limiting decision is made (the
     /// "not allowed but OK" case).
@@ -38,10 +39,11 @@ impl RateLimitingMiddleware for NoOpMiddleware {
 
     #[inline]
     /// Returns `()` and has no side-effects.
-    fn allow<K, P, F>(_key: &K, _when: F) -> Self::PositiveOutcome
+    fn allow<K, P, F, Q>(_key: &K, _when: F, _quota: Q) -> Self::PositiveOutcome
     where
         P: clock::Reference,
         F: Fn() -> P,
+        Q: Fn() -> Quota,
     {
     }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,52 @@
+use core::fmt;
+
+use crate::{clock, nanos::Nanos, NotUntil};
+
+/// Implements additional behavior when rate-limiting decisions are made.
+pub trait RateLimitingMiddleware: fmt::Debug + PartialEq {
+    type PositiveOutcome: Sized;
+
+    /// Called when a positive rate-limiting decision is made.
+    ///
+    /// This function is able to affect the return type of `test` (and
+    /// others) in the Ok case: Whatever is returned here is the value
+    /// of the Ok result returned from the test functions.
+    fn allow<K, P: clock::Reference>(
+        key: &K,
+        decision_at: P,
+        next_tat: Nanos,
+    ) -> Self::PositiveOutcome;
+
+    /// Called when a negative rate-limiting decision is made (the
+    /// "not allowed but OK" case).
+    fn disallow<K, P: clock::Reference>(key: &K, decision_at: P, not_until: &NotUntil<P, Self>)
+    where
+        Self: Sized;
+}
+
+#[derive(PartialEq, Debug)]
+/// A middleware that does nothing and returns `()` in the positive outcome.
+pub struct NoOpMiddleware {}
+
+impl RateLimitingMiddleware for NoOpMiddleware {
+    /// By default, rate limiters return nothing other than an
+    /// indicator that the element should be let through.
+    type PositiveOutcome = ();
+
+    #[inline]
+    /// Returns `()` and has no side-effects.
+    fn allow<K, P: clock::Reference>(
+        _key: &K,
+        _decision_at: P,
+        _next_tat: Nanos,
+    ) -> Self::PositiveOutcome {
+    }
+
+    #[inline]
+    /// Does nothing.
+    fn disallow<K, P: clock::Reference>(_key: &K, _decision_at: P, _not_until: &NotUntil<P, Self>)
+    where
+        Self: Sized,
+    {
+    }
+}

--- a/src/nanos.rs
+++ b/src/nanos.rs
@@ -90,16 +90,19 @@ impl From<Nanos> for Duration {
 }
 
 impl Nanos {
+    #[inline]
     pub(crate) fn saturating_sub(self, rhs: Nanos) -> Nanos {
         Nanos(self.0.saturating_sub(rhs.0))
     }
 }
 
 impl clock::Reference for Nanos {
+    #[inline]
     fn duration_since(&self, earlier: Self) -> Nanos {
         (*self as Nanos).saturating_sub(earlier)
     }
 
+    #[inline]
     fn saturating_sub(&self, duration: Nanos) -> Self {
         (*self as Nanos).saturating_sub(duration)
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -96,6 +96,23 @@ where
     }
 }
 
+impl<K, S, C, MW> RateLimiter<K, S, C, MW>
+where
+    S: StateStore<Key = K>,
+    C: clock::Clock,
+    MW: RateLimitingMiddleware,
+{
+    /// Convert the given rate limiter into one that uses a different middleware.
+    pub fn with_middleware<Outer: RateLimitingMiddleware>(self) -> RateLimiter<K, S, C, Outer> {
+        RateLimiter {
+            state: self.state,
+            gcra: self.gcra.with_middleware(),
+            clock: self.clock,
+            start: self.start,
+        }
+    }
+}
+
 #[cfg(feature = "std")]
 impl<K, S, C, MW> RateLimiter<K, S, C, MW>
 where

--- a/src/state/direct.rs
+++ b/src/state/direct.rs
@@ -8,9 +8,11 @@ use std::prelude::v1::*;
 use std::num::NonZeroU32;
 
 use crate::{
-    clock, middleware::RateLimitingMiddleware, state::InMemoryState, NegativeMultiDecision, Quota,
+    clock,
+    middleware::{NoOpMiddleware, RateLimitingMiddleware},
+    state::InMemoryState,
+    NegativeMultiDecision, Quota,
 };
-use crate::{gcra::NotUntil, middleware::NoOpMiddleware};
 
 /// The "this state store does not use keys" key type.
 ///
@@ -47,7 +49,7 @@ impl RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock, NoOpMiddleware> {
     }
 }
 
-impl<C> RateLimiter<NotKeyed, InMemoryState, C, NoOpMiddleware>
+impl<C> RateLimiter<NotKeyed, InMemoryState, C, NoOpMiddleware<C::Instant>>
 where
     C: clock::Clock,
 {
@@ -63,15 +65,19 @@ impl<S, C, MW> RateLimiter<NotKeyed, S, C, MW>
 where
     S: DirectStateStore,
     C: clock::Clock,
-    MW: RateLimitingMiddleware,
+    MW: RateLimitingMiddleware<C::Instant>,
 {
     /// Allow a single cell through the rate limiter.
     ///
     /// If the rate limit is reached, `check` returns information about the earliest
     /// time that a cell might be allowed through again.
-    pub fn check(&self) -> Result<MW::PositiveOutcome, NotUntil<C::Instant, MW>> {
-        self.gcra
-            .test_and_update(self.start, &NotKeyed::NonKey, &self.state, self.clock.now())
+    pub fn check(&self) -> Result<MW::PositiveOutcome, MW::NegativeOutcome> {
+        self.gcra.test_and_update::<NotKeyed, C::Instant, S, MW>(
+            self.start,
+            &NotKeyed::NonKey,
+            &self.state,
+            self.clock.now(),
+        )
     }
 
     /// Allow *only all* `n` cells through the rate limiter.
@@ -91,14 +97,15 @@ where
     pub fn check_n(
         &self,
         n: NonZeroU32,
-    ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<NotUntil<C::Instant, MW>>> {
-        self.gcra.test_n_all_and_update(
-            self.start,
-            &NotKeyed::NonKey,
-            n,
-            &self.state,
-            self.clock.now(),
-        )
+    ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<MW::NegativeOutcome>> {
+        self.gcra
+            .test_n_all_and_update::<NotKeyed, C::Instant, S, MW>(
+                self.start,
+                &NotKeyed::NonKey,
+                n,
+                &self.state,
+                self.clock.now(),
+            )
     }
 }
 

--- a/src/state/direct.rs
+++ b/src/state/direct.rs
@@ -7,8 +7,8 @@ use std::prelude::v1::*;
 
 use std::num::NonZeroU32;
 
-use crate::gcra::NotUntil;
 use crate::{clock, state::InMemoryState, NegativeMultiDecision, Quota};
+use crate::{gcra::NotUntil, middleware::NoOpMiddleware};
 
 /// The "this state store does not use keys" key type.
 ///
@@ -64,7 +64,7 @@ where
     ///
     /// If the rate limit is reached, `check` returns information about the earliest
     /// time that a cell might be allowed through again.
-    pub fn check(&self) -> Result<(), NotUntil<C::Instant>> {
+    pub fn check(&self) -> Result<(), NotUntil<C::Instant, NoOpMiddleware>> {
         self.gcra
             .test_and_update(self.start, &NotKeyed::NonKey, &self.state, self.clock.now())
     }
@@ -86,7 +86,7 @@ where
     pub fn check_n(
         &self,
         n: NonZeroU32,
-    ) -> Result<(), NegativeMultiDecision<NotUntil<C::Instant>>> {
+    ) -> Result<(), NegativeMultiDecision<NotUntil<C::Instant, NoOpMiddleware>>> {
         self.gcra.test_n_all_and_update(
             self.start,
             &NotKeyed::NonKey,

--- a/src/state/direct/future.rs
+++ b/src/state/direct/future.rs
@@ -5,7 +5,7 @@ use crate::{
     clock,
     middleware::RateLimitingMiddleware,
     state::{DirectStateStore, NotKeyed},
-    Jitter, NegativeMultiDecision,
+    Jitter, NegativeMultiDecision, NotUntil,
 };
 use futures_timer::Delay;
 
@@ -32,7 +32,7 @@ impl<S, C, MW> RateLimiter<NotKeyed, S, C, MW>
 where
     S: DirectStateStore,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware,
+    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/src/state/direct/future.rs
+++ b/src/state/direct/future.rs
@@ -3,6 +3,7 @@ use std::{error::Error, fmt, num::NonZeroU32};
 use super::RateLimiter;
 use crate::{
     clock,
+    middleware::RateLimitingMiddleware,
     state::{DirectStateStore, NotKeyed},
     Jitter, NegativeMultiDecision,
 };
@@ -27,10 +28,11 @@ impl Error for InsufficientCapacity {}
 
 #[cfg(feature = "std")]
 /// # Direct rate limiters - `async`/`await`
-impl<S, C> RateLimiter<NotKeyed, S, C>
+impl<S, C, MW> RateLimiter<NotKeyed, S, C, MW>
 where
     S: DirectStateStore,
     C: clock::ReasonablyRealtime,
+    MW: RateLimitingMiddleware,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/src/state/in_memory.rs
+++ b/src/state/in_memory.rs
@@ -111,16 +111,22 @@ mod test {
     /// Checks that many threads running simultaneously will collide,
     /// but result in the correct number being recorded in the state.
     fn stresstest_collisions() {
+        use all_asserts::assert_gt;
+
         const THREADS: u64 = 8;
         const MAX_TRIES: u64 = 20_000_000;
+        let (mut value, mut hits) = (0, 0);
         for tries in (0..MAX_TRIES).step_by((MAX_TRIES / 100) as usize) {
-            let (value, hits) = try_triggering_collisions(THREADS, tries);
+            let attempt = try_triggering_collisions(THREADS, tries);
+            value = attempt.0;
+            hits = attempt.1;
             assert_eq!(value, tries * THREADS);
             if hits > value {
-                return;
+                break;
             }
             println!("Didn't trigger a collision in {} iterations", tries);
         }
+        assert_gt!(hits, value);
     }
 
     #[test]

--- a/src/state/in_memory.rs
+++ b/src/state/in_memory.rs
@@ -21,9 +21,9 @@ use std::time::Duration;
 pub struct InMemoryState(AtomicU64);
 
 impl InMemoryState {
-    pub(crate) fn measure_and_replace_one<T, F, E>(&self, f: F) -> Result<T, E>
+    pub(crate) fn measure_and_replace_one<T, F, E>(&self, mut f: F) -> Result<T, E>
     where
-        F: Fn(Option<Nanos>) -> Result<(T, Nanos), E>,
+        F: FnMut(Option<Nanos>) -> Result<(T, Nanos), E>,
     {
         let mut prev = self.0.load(Ordering::Acquire);
         let mut decision = f(NonZeroU64::new(prev).map(|n| n.get().into()));
@@ -70,7 +70,59 @@ impl Debug for InMemoryState {
 
 #[cfg(test)]
 mod test {
+
     use super::*;
+
+    #[cfg(feature = "std")]
+    fn try_triggering_collisions(n_threads: u64, tries_per_thread: u64) -> (u64, u64) {
+        use std::sync::Arc;
+        use std::thread;
+
+        let mut state = Arc::new(InMemoryState(AtomicU64::new(0)));
+        let threads: Vec<thread::JoinHandle<_>> = (0..n_threads)
+            .map(|_| {
+                thread::spawn({
+                    let state = Arc::clone(&state);
+                    move || {
+                        let mut hits = 0;
+                        for _ in 0..tries_per_thread {
+                            assert!(state
+                                .measure_and_replace_one(|old| {
+                                    hits += 1;
+                                    Ok::<((), Nanos), ()>((
+                                        (),
+                                        Nanos::from(old.map(Nanos::as_u64).unwrap_or(0) + 1),
+                                    ))
+                                })
+                                .is_ok());
+                        }
+                        hits
+                    }
+                })
+            })
+            .collect();
+        let hits: u64 = threads.into_iter().map(|t| t.join().unwrap()).sum();
+        let value = Arc::get_mut(&mut state).unwrap().0.get_mut();
+        (*value, hits)
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    /// Checks that many threads running simultaneously will collide,
+    /// but result in the correct number being recorded in the state.
+    fn stresstest_collisions() {
+        const THREADS: u64 = 8;
+        const MAX_TRIES: u64 = 20_000_000;
+        for tries in (0..MAX_TRIES).step_by((MAX_TRIES / 100) as usize) {
+            let (value, hits) = try_triggering_collisions(THREADS, tries);
+            assert_eq!(value, tries * THREADS);
+            if hits > value {
+                return;
+            }
+            println!("Didn't trigger a collision in {} iterations", tries);
+        }
+    }
+
     #[test]
     fn in_memory_state_impls() {
         let state = InMemoryState(AtomicU64::new(0));

--- a/src/state/keyed.rs
+++ b/src/state/keyed.rs
@@ -11,12 +11,12 @@ use std::hash::Hash;
 use std::num::NonZeroU32;
 use std::prelude::v1::*;
 
-use crate::state::StateStore;
 use crate::{
     clock::{self, Reference},
     nanos::Nanos,
     NegativeMultiDecision, NotUntil, Quota, RateLimiter,
 };
+use crate::{middleware::NoOpMiddleware, state::StateStore};
 
 /// A trait for state stores with one rate limiting state per key.
 ///
@@ -87,7 +87,7 @@ where
     ///
     /// If the rate limit is reached, `check_key` returns information about the earliest
     /// time that a cell might be allowed through again under that key.
-    pub fn check_key(&self, key: &K) -> Result<(), NotUntil<C::Instant>> {
+    pub fn check_key(&self, key: &K) -> Result<(), NotUntil<C::Instant, NoOpMiddleware>> {
         self.gcra
             .test_and_update(self.start, key, &self.state, self.clock.now())
     }
@@ -110,7 +110,7 @@ where
         &self,
         key: &K,
         n: NonZeroU32,
-    ) -> Result<(), NegativeMultiDecision<NotUntil<C::Instant>>> {
+    ) -> Result<(), NegativeMultiDecision<NotUntil<C::Instant, NoOpMiddleware>>> {
         self.gcra
             .test_n_all_and_update(self.start, key, n, &self.state, self.clock.now())
     }

--- a/src/state/keyed.rs
+++ b/src/state/keyed.rs
@@ -16,7 +16,7 @@ use crate::{
     clock::{self, Reference},
     middleware::RateLimitingMiddleware,
     nanos::Nanos,
-    NegativeMultiDecision, NotUntil, Quota, RateLimiter,
+    NegativeMultiDecision, Quota, RateLimiter,
 };
 
 /// A trait for state stores with one rate limiting state per key.
@@ -83,15 +83,19 @@ where
     S: KeyedStateStore<K>,
     K: Hash,
     C: clock::Clock,
-    MW: RateLimitingMiddleware,
+    MW: RateLimitingMiddleware<C::Instant>,
 {
     /// Allow a single cell through the rate limiter for the given key.
     ///
     /// If the rate limit is reached, `check_key` returns information about the earliest
     /// time that a cell might be allowed through again under that key.
-    pub fn check_key(&self, key: &K) -> Result<MW::PositiveOutcome, NotUntil<C::Instant, MW>> {
-        self.gcra
-            .test_and_update(self.start, key, &self.state, self.clock.now())
+    pub fn check_key(&self, key: &K) -> Result<MW::PositiveOutcome, MW::NegativeOutcome> {
+        self.gcra.test_and_update::<K, C::Instant, S, MW>(
+            self.start,
+            key,
+            &self.state,
+            self.clock.now(),
+        )
     }
 
     /// Allow *only all* `n` cells through the rate limiter for the given key.
@@ -112,9 +116,14 @@ where
         &self,
         key: &K,
         n: NonZeroU32,
-    ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<NotUntil<C::Instant, MW>>> {
-        self.gcra
-            .test_n_all_and_update(self.start, key, n, &self.state, self.clock.now())
+    ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<MW::NegativeOutcome>> {
+        self.gcra.test_n_all_and_update::<K, C::Instant, S, MW>(
+            self.start,
+            key,
+            n,
+            &self.state,
+            self.clock.now(),
+        )
     }
 }
 
@@ -156,11 +165,12 @@ pub trait ShrinkableKeyedStateStore<K: Hash>: KeyedStateStore<K> {
 /// grows, while the number of active keys may stay smaller. To save on space, a keyed rate-limiter
 /// allows removing those keys that are "stale", i.e., whose values are no different from keys' that
 /// aren't present in the rate limiter state store.
-impl<K, S, C> RateLimiter<K, S, C>
+impl<K, S, C, MW> RateLimiter<K, S, C, MW>
 where
     S: ShrinkableKeyedStateStore<K>,
     K: Hash,
     C: clock::Clock,
+    MW: RateLimitingMiddleware<C::Instant>,
 {
     /// Retains all keys in the rate limiter that were used recently enough.
     ///

--- a/src/state/keyed/dashmap.rs
+++ b/src/state/keyed/dashmap.rs
@@ -30,7 +30,7 @@ impl<K: Hash + Eq + Clone> StateStore for DashMapStateStore<K> {
 }
 
 /// # Keyed rate limiters - [`DashMap`]-backed
-impl<K, C> RateLimiter<K, DashMapStateStore<K>, C, NoOpMiddleware>
+impl<K, C> RateLimiter<K, DashMapStateStore<K>, C, NoOpMiddleware<C::Instant>>
 where
     K: Hash + Eq + Clone,
     C: clock::Clock,

--- a/src/state/keyed/dashmap.rs
+++ b/src/state/keyed/dashmap.rs
@@ -3,9 +3,9 @@
 use std::prelude::v1::*;
 
 use crate::nanos::Nanos;
-use crate::state::keyed::ShrinkableKeyedStateStore;
 use crate::state::{InMemoryState, StateStore};
 use crate::{clock, Quota, RateLimiter};
+use crate::{middleware::NoOpMiddleware, state::keyed::ShrinkableKeyedStateStore};
 use dashmap::DashMap;
 use std::hash::Hash;
 
@@ -30,7 +30,7 @@ impl<K: Hash + Eq + Clone> StateStore for DashMapStateStore<K> {
 }
 
 /// # Keyed rate limiters - [`DashMap`]-backed
-impl<K, C> RateLimiter<K, DashMapStateStore<K>, C>
+impl<K, C> RateLimiter<K, DashMapStateStore<K>, C, NoOpMiddleware>
 where
     K: Hash + Eq + Clone,
     C: clock::Clock,

--- a/src/state/keyed/future.rs
+++ b/src/state/keyed/future.rs
@@ -1,7 +1,8 @@
 use std::prelude::v1::*;
 
 use crate::{
-    clock, middleware::RateLimitingMiddleware, state::keyed::KeyedStateStore, Jitter, RateLimiter,
+    clock, middleware::RateLimitingMiddleware, state::keyed::KeyedStateStore, Jitter, NotUntil,
+    RateLimiter,
 };
 use futures_timer::Delay;
 use std::hash::Hash;
@@ -13,7 +14,7 @@ where
     K: Hash + Eq + Clone,
     S: KeyedStateStore<K>,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware,
+    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/src/state/keyed/future.rs
+++ b/src/state/keyed/future.rs
@@ -1,20 +1,19 @@
 use std::prelude::v1::*;
 
 use crate::{
-    clock::{self},
-    state::keyed::KeyedStateStore,
-    Jitter, RateLimiter,
+    clock, middleware::RateLimitingMiddleware, state::keyed::KeyedStateStore, Jitter, RateLimiter,
 };
 use futures_timer::Delay;
 use std::hash::Hash;
 
 #[cfg(feature = "std")]
 /// # Keyed rate limiters - `async`/`await`
-impl<K, S, C> RateLimiter<K, S, C>
+impl<K, S, C, MW> RateLimiter<K, S, C, MW>
 where
     K: Hash + Eq + Clone,
     S: KeyedStateStore<K>,
     C: clock::ReasonablyRealtime,
+    MW: RateLimitingMiddleware,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/src/state/keyed/future.rs
+++ b/src/state/keyed/future.rs
@@ -24,8 +24,8 @@ where
     ///
     /// If multiple futures are dispatched against the rate limiter, it is advisable to use
     /// [`until_ready_with_jitter`](#method.until_ready_with_jitter), to avoid thundering herds.
-    pub async fn until_key_ready(&self, key: &K) {
-        self.until_key_ready_with_jitter(key, Jitter::NONE).await;
+    pub async fn until_key_ready(&self, key: &K) -> MW::PositiveOutcome {
+        self.until_key_ready_with_jitter(key, Jitter::NONE).await
     }
 
     /// Asynchronously resolves as soon as the rate limiter allows it, with a randomized wait
@@ -39,10 +39,21 @@ where
     /// This method allows for a randomized additional delay between polls of the rate limiter,
     /// which can help reduce the likelihood of thundering herd effects if multiple tasks try to
     /// wait on the same rate limiter.
-    pub async fn until_key_ready_with_jitter(&self, key: &K, jitter: Jitter) {
-        while let Err(negative) = self.check_key(key) {
-            let delay = Delay::new(jitter + negative.wait_time_from(self.clock.now()));
-            delay.await;
+    pub async fn until_key_ready_with_jitter(
+        &self,
+        key: &K,
+        jitter: Jitter,
+    ) -> MW::PositiveOutcome {
+        loop {
+            match self.check_key(key) {
+                Ok(x) => {
+                    return x;
+                }
+                Err(negative) => {
+                    let delay = Delay::new(jitter + negative.wait_time_from(self.clock.now()));
+                    delay.await;
+                }
+            }
         }
     }
 }

--- a/src/state/keyed/hashmap.rs
+++ b/src/state/keyed/hashmap.rs
@@ -61,7 +61,7 @@ impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for HashMapStateStore<K>
 }
 
 /// # Keyed rate limiters - [`HashMap`]-backed
-impl<K, C> RateLimiter<K, HashMapStateStore<K>, C, NoOpMiddleware>
+impl<K, C> RateLimiter<K, HashMapStateStore<K>, C, NoOpMiddleware<C::Instant>>
 where
     K: Hash + Eq + Clone,
     C: clock::Clock,

--- a/src/state/keyed/hashmap.rs
+++ b/src/state/keyed/hashmap.rs
@@ -1,8 +1,11 @@
 use std::prelude::v1::*;
 
 use crate::nanos::Nanos;
-use crate::state::{InMemoryState, StateStore};
 use crate::{clock, Quota, RateLimiter};
+use crate::{
+    middleware::NoOpMiddleware,
+    state::{InMemoryState, StateStore},
+};
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -58,7 +61,7 @@ impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for HashMapStateStore<K>
 }
 
 /// # Keyed rate limiters - [`HashMap`]-backed
-impl<K, C> RateLimiter<K, HashMapStateStore<K>, C>
+impl<K, C> RateLimiter<K, HashMapStateStore<K>, C, NoOpMiddleware>
 where
     K: Hash + Eq + Clone,
     C: clock::Clock,

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "std")]
 
+use all_asserts::*;
 use futures::executor::block_on;
 use governor::{Quota, RateLimiter};
-use more_asserts::*;
 use nonzero_ext::*;
 use std::sync::Arc;
 use std::thread;
@@ -98,12 +98,7 @@ fn multiple() {
     // by now we've waited for, on average, 10ms; but sometimes the
     // test finishes early; let's assume it takes at least 8ms:
     let elapsed = i.elapsed();
-    assert_ge!(
-        elapsed,
-        Duration::from_millis(8),
-        "Expected to wait some time, but waited: {:?}",
-        elapsed
-    );
+    assert_ge!(elapsed, Duration::from_millis(8),);
 }
 
 #[test]
@@ -124,12 +119,7 @@ fn multiple_keyed() {
     // by now we've waited for, on average, 10ms; but sometimes the
     // test finishes early; let's assume it takes at least 8ms:
     let elapsed = i.elapsed();
-    assert_ge!(
-        elapsed,
-        Duration::from_millis(8),
-        "Expected to wait some time, but waited: {:?}",
-        elapsed
-    );
+    assert_ge!(elapsed, Duration::from_millis(8),);
 }
 
 #[test]

--- a/tests/keyed_dashmap.rs
+++ b/tests/keyed_dashmap.rs
@@ -1,10 +1,10 @@
 #![cfg(all(feature = "std", feature = "dashmap"))]
 
-use governor::state::keyed::DashMapStateStore;
 use governor::{
     clock::{Clock, FakeRelativeClock},
     Quota, RateLimiter,
 };
+use governor::{middleware::NoOpMiddleware, state::keyed::DashMapStateStore};
 use nonzero_ext::nonzero;
 use std::hash::Hash;
 use std::time::Duration;
@@ -48,7 +48,12 @@ fn rejects_too_many() {
 
 fn retained_keys<T: Clone + Hash + Eq + Copy + Ord>(
     keys: &[T],
-    limiter: RateLimiter<T, DashMapStateStore<T>, FakeRelativeClock>,
+    limiter: RateLimiter<
+        T,
+        DashMapStateStore<T>,
+        FakeRelativeClock,
+        NoOpMiddleware<<FakeRelativeClock as Clock>::Instant>,
+    >,
 ) -> Vec<T> {
     let state = limiter.into_state_store();
     let mut keys: Vec<T> = keys

--- a/tests/keyed_hashmap.rs
+++ b/tests/keyed_hashmap.rs
@@ -1,8 +1,8 @@
-use governor::state::keyed::HashMapStateStore;
 use governor::{
     clock::{Clock, FakeRelativeClock},
     Quota, RateLimiter,
 };
+use governor::{middleware::NoOpMiddleware, state::keyed::HashMapStateStore};
 use nonzero_ext::nonzero;
 use std::hash::Hash;
 use std::time::Duration;
@@ -45,7 +45,12 @@ fn rejects_too_many() {
 }
 
 fn retained_keys<T: Clone + Hash + Eq + Copy + Ord>(
-    limiter: RateLimiter<T, HashMapStateStore<T>, FakeRelativeClock>,
+    limiter: RateLimiter<
+        T,
+        HashMapStateStore<T>,
+        FakeRelativeClock,
+        NoOpMiddleware<<FakeRelativeClock as Clock>::Instant>,
+    >,
 ) -> Vec<T> {
     let state = limiter.into_state_store();
     let map = state.lock();

--- a/tests/memory_leaks.rs
+++ b/tests/memory_leaks.rs
@@ -3,6 +3,7 @@
 // This test uses procinfo, so can only be run on Linux.
 extern crate libc;
 
+use all_asserts::*;
 use governor::{Quota, RateLimiter};
 use nonzero_ext::*;
 use std::sync::Arc;
@@ -24,13 +25,7 @@ struct LeakCheck {
 impl Drop for LeakCheck {
     fn drop(&mut self) {
         let usage_after = resident_memory_size();
-        assert!(
-            usage_after <= self.usage_before + LEAK_TOLERANCE,
-            "Plausible memory leak!\nAfter {} iterations, usage before: {}, usage after: {}",
-            self.n_iter,
-            self.usage_before,
-            usage_after
-        );
+        assert_le!(usage_after, self.usage_before + LEAK_TOLERANCE);
     }
 }
 

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -1,4 +1,8 @@
-use governor::{clock, Quota, RateLimiter, RateLimitingMiddleware};
+use governor::{
+    clock,
+    middleware::{RateLimitingMiddleware, StateSnapshot},
+    Quota, RateLimiter,
+};
 use nonzero_ext::nonzero;
 
 #[derive(Debug, PartialEq)]
@@ -7,18 +11,16 @@ struct MyMW {}
 impl RateLimitingMiddleware for MyMW {
     type PositiveOutcome = u16;
 
-    fn allow<K, P, F, Q>(_key: &K, _when: F, _quota: Q) -> Self::PositiveOutcome
+    fn allow<K, P>(_key: &K, _state: StateSnapshot<P>) -> Self::PositiveOutcome
     where
         P: clock::Reference,
-        F: Fn() -> P,
-        Q: Fn() -> Quota,
     {
         666
     }
 
     fn disallow<K, P: governor::clock::Reference>(
         _key: &K,
-        _decision_at: P,
+        _state: StateSnapshot<P>,
         _not_until: &governor::NotUntil<P, Self>,
     ) where
         Self: Sized,

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -21,10 +21,7 @@ impl RateLimitingMiddleware<<FakeRelativeClock as clock::Clock>::Instant> for My
         _key: &K,
         _limiter: impl Into<StateSnapshot>,
         _start_time: <FakeRelativeClock as clock::Clock>::Instant,
-    ) -> Self::NegativeOutcome
-    where
-        Self: Sized,
-    {
+    ) -> Self::NegativeOutcome {
         ()
     }
 }

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -1,5 +1,5 @@
 use governor::{
-    clock,
+    clock::{self, FakeRelativeClock},
     middleware::{RateLimitingMiddleware, StateSnapshot},
     Quota, RateLimiter,
 };
@@ -30,6 +30,8 @@ impl RateLimitingMiddleware for MyMW {
 
 #[test]
 fn changes_allowed_type() {
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(4u32))).with_middleware::<MyMW>();
+    let clock = FakeRelativeClock::default();
+    let lim = RateLimiter::direct_with_clock(Quota::per_second(nonzero!(4u32)), &clock)
+        .with_middleware::<MyMW>();
     assert_eq!(Ok(666), lim.check());
 }

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -7,10 +7,11 @@ struct MyMW {}
 impl RateLimitingMiddleware for MyMW {
     type PositiveOutcome = u16;
 
-    fn allow<K, P, F>(_key: &K, _when: F) -> Self::PositiveOutcome
+    fn allow<K, P, F, Q>(_key: &K, _when: F, _quota: Q) -> Self::PositiveOutcome
     where
         P: clock::Reference,
         F: Fn() -> P,
+        Q: Fn() -> Quota,
     {
         666
     }

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -1,0 +1,32 @@
+use governor::{clock, Quota, RateLimiter, RateLimitingMiddleware};
+use nonzero_ext::nonzero;
+
+#[derive(Debug, PartialEq)]
+struct MyMW {}
+
+impl RateLimitingMiddleware for MyMW {
+    type PositiveOutcome = u16;
+
+    fn allow<K, P, F>(_key: &K, _when: F) -> Self::PositiveOutcome
+    where
+        P: clock::Reference,
+        F: Fn() -> P,
+    {
+        666
+    }
+
+    fn disallow<K, P: governor::clock::Reference>(
+        _key: &K,
+        _decision_at: P,
+        _not_until: &governor::NotUntil<P, Self>,
+    ) where
+        Self: Sized,
+    {
+    }
+}
+
+#[test]
+fn changes_allowed_type() {
+    let lim = RateLimiter::direct(Quota::per_second(nonzero!(4u32))).with_middleware::<MyMW>();
+    assert_eq!(Ok(666), lim.check());
+}

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -43,9 +43,10 @@ impl RateLimitingMiddleware<<FakeRelativeClock as clock::Clock>::Instant> for My
 #[test]
 fn changes_allowed_type() {
     let clock = FakeRelativeClock::default();
-    let lim = RateLimiter::direct_with_clock(Quota::per_second(nonzero!(4u32)), &clock)
+    let lim = RateLimiter::direct_with_clock(Quota::per_hour(nonzero!(1_u32)), &clock)
         .with_middleware::<MyMW>();
     assert_eq!(Ok(666), lim.check());
+    assert_eq!(Err(NotAllowed), lim.check());
 }
 
 #[test]

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -7,8 +7,8 @@ use governor::{
 };
 use nonzero_ext::nonzero;
 
-#[derive(Debug, PartialEq)]
-struct MyMW {}
+#[derive(Debug)]
+struct MyMW;
 
 #[derive(Debug, PartialEq)]
 struct NotAllowed;
@@ -74,4 +74,12 @@ fn state_information() {
             .map(|outcome| outcome.remaining_burst_capacity())
     );
     assert!(lim.check().is_err());
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn mymw_derives() {
+    assert_eq!(NotAllowed, NotAllowed);
+    assert_eq!(format!("{}", NotAllowed), "Not allowed yet");
+    assert_eq!(format!("{:?}", MyMW), "MyMW");
 }

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -8,7 +8,7 @@ use proptest::prelude::prop::test_runner::FileFailurePersistence;
 use std::num::NonZeroU32;
 use std::time::Duration;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 struct Count(NonZeroU32);
 impl Arbitrary for Count {
     type Parameters = ();
@@ -27,6 +27,14 @@ fn test_config() -> ProptestConfig {
     //cfg.timeout = 20;
     cfg.verbose = 0; // 2 for extra verbosity;
     cfg
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn cover_count_derives() {
+    use nonzero_ext::nonzero;
+    let count = Count(nonzero!(1u32));
+    assert_eq!(format!("{:?}", count), "Count(1)");
 }
 
 #[test]

--- a/tests/sinks.rs
+++ b/tests/sinks.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "std")]
 
+use all_asserts::*;
 use futures::executor::block_on;
 use futures::SinkExt;
 use governor::{prelude::*, Jitter, Quota, RateLimiter};
@@ -16,27 +17,13 @@ fn sink() {
     for _ in 0..10 {
         block_on(sink.send(())).unwrap();
     }
-    assert!(
-        i.elapsed() <= Duration::from_millis(100),
-        "elapsed: {:?}",
-        i.elapsed()
-    );
+    assert_lt!(i.elapsed(), Duration::from_millis(100));
 
     block_on(sink.send(())).unwrap();
-    assert!(
-        i.elapsed() > Duration::from_millis(100),
-        "elapsed: {:?}",
-        i.elapsed()
-    );
-    assert!(
-        i.elapsed() <= Duration::from_millis(200),
-        "elapsed: {:?}",
-        i.elapsed()
-    );
+    assert_range!((100..=200), i.elapsed().as_millis());
 
     block_on(sink.send(())).unwrap();
-    assert!(i.elapsed() > Duration::from_millis(200));
-    assert!(i.elapsed() <= Duration::from_millis(300));
+    assert_range!((200..=300), i.elapsed().as_millis());
 
     let result = sink.get_ref();
     assert_eq!(result.len(), 12);
@@ -65,27 +52,13 @@ fn sink_with_jitter() {
     for _ in 0..10 {
         block_on(sink.send(())).unwrap();
     }
-    assert!(
-        i.elapsed() <= Duration::from_millis(100),
-        "elapsed: {:?}",
-        i.elapsed()
-    );
+    assert_le!(i.elapsed(), Duration::from_millis(100),);
 
     block_on(sink.send(())).unwrap();
-    assert!(
-        i.elapsed() > Duration::from_millis(100),
-        "elapsed: {:?}",
-        i.elapsed()
-    );
-    assert!(
-        i.elapsed() <= Duration::from_millis(200),
-        "elapsed: {:?}",
-        i.elapsed()
-    );
+    assert_range!((100..=200), i.elapsed().as_millis());
 
     block_on(sink.send(())).unwrap();
-    assert!(i.elapsed() > Duration::from_millis(200));
-    assert!(i.elapsed() <= Duration::from_millis(300));
+    assert_range!((200..=300), i.elapsed().as_millis());
 
     let result = sink.into_inner();
     assert_eq!(result.len(), 12);


### PR DESCRIPTION
This addresses #66.

When making using a rate-limiter, it's sometimes useful to have information about what the state of the limiter (and the state for a particular user, in particular) is. This change will keep everything the same by default (returning `Ok(())` if a cell is allowed), but allows extending the behavior & some side effects.

The way this is structured should allow for middleware that:

* computes the remaining burst capacity in a way that can be presented to the user,
* counts the number of times a key has been used, in e.g. prometheus.

Some things remain TODO:
- [x] A middleware that returns the state
- [x] check that the middleware is threaded through correctly everywhere in docs
- [x] Benchmark this against the main branch, to ensure we're remaining cost-free in default usage.
- [x] update the guide
- [x] a changelog entry that sums this up
- [x] tests for all the conditions where you'd use it
- [x] Maybe remove the middleware from the Gcra
- [x] add a NegativeOutcome type to the middleware
- [x] get coverage to not lie again (some lines seem uncovered, but they're from failed assertions! Argh!)