### PR TITLE
Improve coverage exclusion parameters

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,13 +9,19 @@ jobs:
   code_coverage:
     runs-on: ubuntu-latest
     steps:
+      - name: Set grcov parameters
+        run: |
+          cat <<EOT >> $GITHUB_ENV
+          grcov_version=0.8.0
+          excl_line<<EOV
+          (unreachable!\(|#\[derive\(|(debug_)?assert(|_[a-z]+)!\()
+          EOV
+          EOT
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: false
-
-      - name: Set grcov version
-        run: echo "grcov_version=0.8.0" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
 
@@ -51,7 +57,7 @@ jobs:
       - name: Run grcov for tests
         run: |
           mkdir coverage
-          grcov . --binary-path target/debug/deps/ -s . -t lcov --excl-line '!no_rcov!' --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/tests.lcov
+          grcov . --binary-path target/debug/deps/ -s . -t lcov --excl-line '${{env.excl_line}}' --excl-br-line '${{env.excl_line}}' --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/tests.lcov
           grcov . --binary-path target/debug/doctestbins/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/doctests.lcov
 
       - name: Upload to codecov.io

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run grcov for tests
         run: |
           mkdir coverage
-          grcov . --binary-path target/debug/deps/ -s . -t lcov --excl-start '${{env.excl_expr_start}}' --excl-br-start '${{env.excl_expr_start}}' --excl-stop '${{env.excl_expr_stop}}' --excl-br-stop '${{env.excl_expr_stop}}' --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/tests.lcov
+          grcov . --binary-path target/debug/deps/ -s . -t lcov --excl-br-line '${{env.excl_expr_start}}' --excl-line '${{env.excl_expr_start}}' --excl-start '${{env.excl_expr_start}}' --excl-br-start '${{env.excl_expr_start}}' --excl-stop '${{env.excl_expr_stop}}' --excl-br-stop '${{env.excl_expr_stop}}' --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/tests.lcov
           grcov . --binary-path target/debug/doctestbins/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/doctests.lcov
 
       - name: Upload to codecov.io

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,9 +13,10 @@ jobs:
         run: |
           cat <<EOT >> $GITHUB_ENV
           grcov_version=0.8.0
-          excl_line<<EOV
-          (unreachable!\(|#\[derive\(|(debug_)?assert(|_[a-z]+)!\()
+          excl_expr_start<<EOV
+          (unreachable!\(|(debug_)?assert(|_[a-z]+)!\()
           EOV
+          excl_expr_stop=\);
           EOT
 
       - uses: actions-rs/toolchain@v1
@@ -57,7 +58,7 @@ jobs:
       - name: Run grcov for tests
         run: |
           mkdir coverage
-          grcov . --binary-path target/debug/deps/ -s . -t lcov --excl-line '${{env.excl_line}}' --excl-br-line '${{env.excl_line}}' --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/tests.lcov
+          grcov . --binary-path target/debug/deps/ -s . -t lcov --excl-start '${{env.excl_expr_start}}' --excl-br-start '${{env.excl_expr_start}}' --excl-stop '${{env.excl_expr_stop}}' --excl-br-stop '${{env.excl_expr_stop}}' --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/tests.lcov
           grcov . --binary-path target/debug/doctestbins/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage/doctests.lcov
 
       - name: Upload to codecov.io


### PR DESCRIPTION
We don't want to count coverage on:

* `unreachable!` lines
* `assert` lines

As those end up not getting executed if the tests succeed.