### PR TITLE
No hashbrown when using std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ all_asserts = "2.2.0"
 default = ["std", "dashmap", "jitter", "quanta"]
 std = ["no-std-compat/std", "nonzero_ext/std", "futures-timer", "futures"]
 jitter = ["rand"]
-no_std = []
+no_std = ["no-std-compat/compat_hash"]
 
 [dependencies]
 nonzero_ext = { version = "0.2.0", default-features = false }
@@ -48,7 +48,7 @@ futures = { version = "0.3.5", optional = true }
 rand = { version = "0.8.0", optional = true }
 dashmap = { version = "4.0.2", optional = true }
 quanta = { version = "0.9.0", optional = true }
-no-std-compat = { version = "0.4.0", features = [ "alloc", "compat_hash" ] }
+no-std-compat = { version = "0.4.1", features = [ "alloc" ] }
 
 # To ensure we don't pull in vulnerable smallvec, see https://github.com/antifuchs/governor/issues/60
 smallvec = "1.6.1"


### PR DESCRIPTION
This feature is only useful when using no_std