### PR TITLE
Conditionalize-out the Instant::now test on M1 macs

### DIFF
--- a/governor/Cargo.toml
+++ b/governor/Cargo.toml
@@ -49,6 +49,7 @@ rand = { version = "0.8.0", optional = true }
 dashmap = { version = "5.1.0", optional = true }
 quanta = { version = "0.9.0", optional = true }
 no-std-compat = { version = "0.4.1", features = [ "alloc" ] }
+cfg-if = "0.1"
 
 # To ensure we don't pull in vulnerable smallvec, see https://github.com/antifuchs/governor/issues/60
 smallvec = "1.6.1"


### PR DESCRIPTION
It's flaky, due to a change in clock resolution. As it's not extremely
relevant to correctness, and really needs only run in CI (where we run
it on linux machines).

Fixes #114 