### PR TITLE
fix testing bug and clippy lints

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,7 @@ allow = [
     "BSD-3-Clause",
     "BSD-2-Clause",
     "MIT",
-    "CC0-1.0",  # more_asserts
+    "Unicode-DFS-2016",
 ]
 deny = []
 copyleft = "warn"

--- a/governor/src/clock.rs
+++ b/governor/src/clock.rs
@@ -205,7 +205,7 @@ mod test {
             .map(move |_| {
                 let clock = Arc::clone(&clock);
                 thread::spawn(move || {
-                    for _ in (0..1000000).into_iter() {
+                    for _ in 0..1000000 {
                         let now = clock.now();
                         clock.advance(Duration::from_nanos(1));
                         assert!(clock.now() > now);

--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -124,8 +124,7 @@ mod test {
         // let _c1 =
         //     QuantaUpkeepClock::from_builder(quanta::Upkeep::new(Duration::from_secs(1))).unwrap();
         let c = QuantaUpkeepClock::from_interval(Duration::from_secs(1))
-            .unwrap()
-            .clone();
+            .unwrap();
         let now = c.now();
         assert_ne!(now + one_ns, now);
         assert_eq!(one_ns, Reference::duration_since(&(now + one_ns), now));

--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -123,8 +123,7 @@ mod test {
         let one_ns = Nanos::new(1);
         // let _c1 =
         //     QuantaUpkeepClock::from_builder(quanta::Upkeep::new(Duration::from_secs(1))).unwrap();
-        let c = QuantaUpkeepClock::from_interval(Duration::from_secs(1))
-            .unwrap();
+        let c = QuantaUpkeepClock::from_interval(Duration::from_secs(1)).unwrap();
         let now = c.now();
         assert_ne!(now + one_ns, now);
         assert_eq!(one_ns, Reference::duration_since(&(now + one_ns), now));

--- a/governor/src/errors.rs
+++ b/governor/src/errors.rs
@@ -11,7 +11,7 @@
 ///   * `InsufficientCapacity` - the query was invalid as the rate
 ///     limite parameters can never accomodate the number of cells
 ///     queried for.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum NegativeMultiDecision<E> {
     /// A batch of cells (the first argument) is non-conforming and
     /// can not be let through at this time. The second argument gives

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -18,7 +18,7 @@ pub struct NotUntil<P: clock::Reference> {
     start: P,
 }
 
-impl<'a, P: clock::Reference> NotUntil<P> {
+impl<P: clock::Reference> NotUntil<P> {
     /// Create a `NotUntil` as a negative rate-limiting result.
     #[inline]
     pub(crate) fn new(state: StateSnapshot, start: P) -> Self {
@@ -67,7 +67,7 @@ impl<'a, P: clock::Reference> NotUntil<P> {
     }
 }
 
-impl<'a, P: clock::Reference> fmt::Display for NotUntil<P> {
+impl<P: clock::Reference> fmt::Display for NotUntil<P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "rate-limited until {:?}", self.start + self.state.tat)
     }
@@ -190,13 +190,14 @@ mod test {
     #[cfg(feature = "std")]
     #[test]
     fn gcra_derives() {
+        use all_asserts::assert_gt;
         use nonzero_ext::nonzero;
 
         let g = Gcra::new(Quota::per_second(nonzero!(1u32)));
         let g2 = Gcra::new(Quota::per_second(nonzero!(2u32)));
         assert_eq!(g, g);
         assert_ne!(g, g2);
-        assert!(format!("{:?}", g).len() > 0);
+        assert_gt!(format!("{:?}", g).len(), 0);
     }
 
     /// Exercise derives and convenience impls on NotUntil to make coverage happy
@@ -204,6 +205,7 @@ mod test {
     #[test]
     fn notuntil_impls() {
         use crate::RateLimiter;
+        use all_asserts::assert_gt;
         use clock::FakeRelativeClock;
         use nonzero_ext::nonzero;
 
@@ -215,7 +217,7 @@ mod test {
             .check()
             .map_err(|nu| {
                 assert_eq!(nu, nu);
-                assert!(format!("{:?}", nu).len() > 0);
+                assert_gt!(format!("{:?}", nu).len(), 0);
                 assert_eq!(format!("{}", nu), "rate-limited until Nanos(1s)");
                 assert_eq!(nu.quota(), quota);
             })

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -12,7 +12,7 @@ use crate::Jitter;
 ///
 /// `NotUntil`'s methods indicate when a caller can expect the next positive
 /// rate-limiting result.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct NotUntil<P: clock::Reference> {
     state: StateSnapshot,
     start: P,
@@ -73,7 +73,7 @@ impl<P: clock::Reference> fmt::Display for NotUntil<P> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Gcra {
     /// The "weight" of a single packet in units of time.
     t: Nanos,

--- a/governor/src/jitter.rs
+++ b/governor/src/jitter.rs
@@ -57,7 +57,7 @@ use std::time::Instant;
 /// # }
 /// # #[cfg(any(not(feature = "jitter"), not(feature = "std")))] fn main() {}
 /// ```
-#[derive(Debug, PartialEq, Default, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 #[cfg_attr(feature = "docs", doc(cfg(jitter)))]
 pub struct Jitter {
     min: Nanos,

--- a/governor/src/middleware.rs
+++ b/governor/src/middleware.rs
@@ -69,7 +69,7 @@ use std::{cmp, marker::PhantomData};
 use crate::{clock, nanos::Nanos, NotUntil, Quota};
 
 /// Information about the rate-limiting state used to reach a decision.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StateSnapshot {
     /// The "weight" of a single packet in units of time.
     t: Nanos,

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -134,11 +134,12 @@ where
 mod test {
     use super::*;
     use crate::Quota;
+    use all_asserts::assert_gt;
     use nonzero_ext::nonzero;
 
     #[test]
     fn ratelimiter_impl_coverage() {
         let lim = RateLimiter::direct(Quota::per_second(nonzero!(3u32)));
-        assert!(format!("{:?}", lim).len() > 0);
+        assert_gt!(format!("{:?}", lim).len(), 0);
     }
 }

--- a/governor/src/state/direct/future.rs
+++ b/governor/src/state/direct/future.rs
@@ -118,12 +118,14 @@ where
 
 #[cfg(test)]
 mod test {
+    use all_asserts::assert_gt;
+
     use super::*;
 
     #[test]
     fn insufficient_capacity_impl_coverage() {
         let i = InsufficientCapacity(1);
         assert_eq!(i.0, i.clone().0);
-        assert!(format!("{}", i).len() > 0);
+        assert_gt!(format!("{}", i).len(), 0);
     }
 }

--- a/governor/src/state/in_memory.rs
+++ b/governor/src/state/in_memory.rs
@@ -69,7 +69,10 @@ impl Debug for InMemoryState {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_collect)]
 mod test {
+
+    use all_asserts::assert_gt;
 
     use super::*;
 
@@ -132,6 +135,6 @@ mod test {
     #[test]
     fn in_memory_state_impls() {
         let state = InMemoryState(AtomicU64::new(0));
-        assert!(format!("{:?}", state).len() > 0);
+        assert_gt!(format!("{:?}", state).len(), 0);
     }
 }

--- a/governor/tests/future.rs
+++ b/governor/tests/future.rs
@@ -55,7 +55,6 @@ fn pauses_keyed() {
 
 #[test]
 fn proceeds() {
-
     let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
     let i = Instant::now();
     block_on(lim.until_ready());

--- a/governor/tests/future.rs
+++ b/governor/tests/future.rs
@@ -8,9 +8,10 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+const WAIT_UNTIL_PROCEEDS: u64 = 50;
+
 #[test]
 fn pauses() {
-    let i = Instant::now();
     let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
 
     // exhaust the limiter:
@@ -19,20 +20,19 @@ fn pauses() {
             break;
         }
     }
-
+    let i = Instant::now();
     block_on(lim.until_ready());
     assert_ge!(i.elapsed(), Duration::from_millis(100));
 }
 
 #[test]
 fn pauses_n() {
-    let i = Instant::now();
     let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
 
     for _ in 0..6 {
         lim.check().unwrap();
     }
-
+    let i = Instant::now();
     block_on(lim.until_n_ready(nonzero!(5u32))).unwrap();
     assert_ge!(i.elapsed(), Duration::from_millis(100));
 }
@@ -55,37 +55,34 @@ fn pauses_keyed() {
 
 #[test]
 fn proceeds() {
-    let i = Instant::now();
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
 
+    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+    let i = Instant::now();
     block_on(lim.until_ready());
-    assert_le!(i.elapsed(), Duration::from_millis(100));
+    assert_le!(i.elapsed(), Duration::from_micros(WAIT_UNTIL_PROCEEDS));
 }
 
 #[test]
 fn proceeds_n() {
-    let i = Instant::now();
     let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
-
+    let i = Instant::now();
     block_on(lim.until_n_ready(nonzero!(10u32))).unwrap();
-    assert_le!(i.elapsed(), Duration::from_millis(100));
+    assert_le!(i.elapsed(), Duration::from_micros(WAIT_UNTIL_PROCEEDS));
 }
 
 #[test]
 fn proceeds_keyed() {
-    let i = Instant::now();
     let lim = RateLimiter::keyed(Quota::per_second(nonzero!(10u32)));
-
+    let i = Instant::now();
     block_on(lim.until_key_ready(&1u32));
-    assert_le!(i.elapsed(), Duration::from_millis(100));
+    assert_le!(i.elapsed(), Duration::from_micros(WAIT_UNTIL_PROCEEDS));
 }
 
 #[test]
 fn multiple() {
-    let i = Instant::now();
     let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
     let mut children = vec![];
-
+    let i = Instant::now();
     for _i in 0..20 {
         let lim = Arc::clone(&lim);
         children.push(thread::spawn(move || {
@@ -103,10 +100,10 @@ fn multiple() {
 
 #[test]
 fn multiple_keyed() {
-    let i = Instant::now();
     let lim = Arc::new(RateLimiter::keyed(Quota::per_second(nonzero!(10u32))));
     let mut children = vec![];
 
+    let i = Instant::now();
     for _i in 0..20 {
         let lim = Arc::clone(&lim);
         children.push(thread::spawn(move || {

--- a/governor/tests/middleware.rs
+++ b/governor/tests/middleware.rs
@@ -23,7 +23,8 @@ impl RateLimitingMiddleware<<FakeRelativeClock as clock::Clock>::Instant> for My
         _key: &K,
         _limiter: impl Into<StateSnapshot>,
         _start_time: <FakeRelativeClock as clock::Clock>::Instant,
-    ) -> Self::NegativeOutcome {}
+    ) -> Self::NegativeOutcome {
+    }
 }
 
 #[test]

--- a/governor/tests/middleware.rs
+++ b/governor/tests/middleware.rs
@@ -23,9 +23,7 @@ impl RateLimitingMiddleware<<FakeRelativeClock as clock::Clock>::Instant> for My
         _key: &K,
         _limiter: impl Into<StateSnapshot>,
         _start_time: <FakeRelativeClock as clock::Clock>::Instant,
-    ) -> Self::NegativeOutcome {
-        ()
-    }
+    ) -> Self::NegativeOutcome {}
 }
 
 #[test]

--- a/governor/tests/proptests.rs
+++ b/governor/tests/proptests.rs
@@ -4,7 +4,7 @@ use governor::{
     clock::{Clock, FakeRelativeClock},
     Quota, RateLimiter,
 };
-use proptest::prelude::prop::test_runner::FileFailurePersistence;
+use proptest::prelude::prop::test_runner::{Config, FileFailurePersistence};
 use std::num::NonZeroU32;
 use std::time::Duration;
 
@@ -22,11 +22,12 @@ impl Arbitrary for Count {
 }
 
 fn test_config() -> ProptestConfig {
-    let mut cfg = ProptestConfig::default();
-    cfg.failure_persistence = Some(Box::new(FileFailurePersistence::WithSource("regressions")));
-    //cfg.timeout = 20;
-    cfg.verbose = 0; // 2 for extra verbosity;
-    cfg
+    Config {
+        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("regressions"))),
+        verbose: 0,
+        timeout: 20,
+        ..Default::default()
+    }
 }
 
 #[cfg(feature = "std")]

--- a/governor/tests/sinks.rs
+++ b/governor/tests/sinks.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 use governor::Jitter;
 
 #[test]
+#[allow(clippy::unit_cmp)]
 fn sink() {
     let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
     let mut sink = Vec::new().ratelimit_sink(&lim);
@@ -30,7 +31,7 @@ fn sink() {
 
     let result = sink.get_ref();
     assert_eq!(result.len(), 12);
-    assert!(result.into_iter().all(|&elt| elt == ()));
+    assert!(result.iter().all(|&elt| elt == ()));
 }
 
 #[test]
@@ -47,6 +48,7 @@ fn auxilliary_sink_methods() {
 
 #[cfg(all(feature = "jitter", test))]
 #[cfg_attr(feature = "jitter", test)]
+#[allow(clippy::unit_cmp)]
 fn sink_with_jitter() {
     let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
     let mut sink =


### PR DESCRIPTION
This PR fixes Clippy complaining with 1.6.2 version of Rust and moves the timestamp creation for multiple tests after the instantiation of the Rate Limiter.