### PR TITLE
Preview decision and remove individual keys

### DIFF
--- a/governor/src/clock.rs
+++ b/governor/src/clock.rs
@@ -205,7 +205,7 @@ mod test {
             .map(move |_| {
                 let clock = Arc::clone(&clock);
                 thread::spawn(move || {
-                    for _ in (0..1000000).into_iter() {
+                    for _ in 0..1000000 {
                         let now = clock.now();
                         clock.advance(Duration::from_nanos(1));
                         assert!(clock.now() > now);

--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -124,8 +124,7 @@ mod test {
         // let _c1 =
         //     QuantaUpkeepClock::from_builder(quanta::Upkeep::new(Duration::from_secs(1))).unwrap();
         let c = QuantaUpkeepClock::from_interval(Duration::from_secs(1))
-            .unwrap()
-            .clone();
+            .unwrap();
         let now = c.now();
         assert_ne!(now + one_ns, now);
         assert_eq!(one_ns, Reference::duration_since(&(now + one_ns), now));

--- a/governor/src/errors.rs
+++ b/governor/src/errors.rs
@@ -11,7 +11,7 @@
 ///   * `InsufficientCapacity` - the query was invalid as the rate
 ///     limite parameters can never accomodate the number of cells
 ///     queried for.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum NegativeMultiDecision<E> {
     /// A batch of cells (the first argument) is non-conforming and
     /// can not be let through at this time. The second argument gives

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -12,7 +12,7 @@ use crate::Jitter;
 ///
 /// `NotUntil`'s methods indicate when a caller can expect the next positive
 /// rate-limiting result.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct NotUntil<P: clock::Reference> {
     state: StateSnapshot,
     start: P,

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -18,7 +18,7 @@ pub struct NotUntil<P: clock::Reference> {
     start: P,
 }
 
-impl<'a, P: clock::Reference> NotUntil<P> {
+impl<P: clock::Reference> NotUntil<P> {
     /// Create a `NotUntil` as a negative rate-limiting result.
     #[inline]
     pub(crate) fn new(state: StateSnapshot, start: P) -> Self {
@@ -67,7 +67,7 @@ impl<'a, P: clock::Reference> NotUntil<P> {
     }
 }
 
-impl<'a, P: clock::Reference> fmt::Display for NotUntil<P> {
+impl<P: clock::Reference> fmt::Display for NotUntil<P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "rate-limited until {:?}", self.start + self.state.tat)
     }
@@ -196,7 +196,7 @@ mod test {
         let g2 = Gcra::new(Quota::per_second(nonzero!(2u32)));
         assert_eq!(g, g);
         assert_ne!(g, g2);
-        assert!(format!("{:?}", g).len() > 0);
+        assert!(!format!("{:?}", g).is_empty());
     }
 
     /// Exercise derives and convenience impls on NotUntil to make coverage happy
@@ -215,7 +215,7 @@ mod test {
             .check()
             .map_err(|nu| {
                 assert_eq!(nu, nu);
-                assert!(format!("{:?}", nu).len() > 0);
+                assert!(!format!("{:?}", nu).is_empty());
                 assert_eq!(format!("{}", nu), "rate-limited until Nanos(1s)");
                 assert_eq!(nu.quota(), quota);
             })

--- a/governor/src/jitter.rs
+++ b/governor/src/jitter.rs
@@ -57,7 +57,7 @@ use std::time::Instant;
 /// # }
 /// # #[cfg(any(not(feature = "jitter"), not(feature = "std")))] fn main() {}
 /// ```
-#[derive(Debug, PartialEq, Default, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 #[cfg_attr(feature = "docs", doc(cfg(jitter)))]
 pub struct Jitter {
     min: Nanos,

--- a/governor/src/middleware.rs
+++ b/governor/src/middleware.rs
@@ -69,7 +69,7 @@ use std::{cmp, marker::PhantomData};
 use crate::{clock, nanos::Nanos, NotUntil, Quota};
 
 /// Information about the rate-limiting state used to reach a decision.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StateSnapshot {
     /// The "weight" of a single packet in units of time.
     t: Nanos,

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -139,6 +139,6 @@ mod test {
     #[test]
     fn ratelimiter_impl_coverage() {
         let lim = RateLimiter::direct(Quota::per_second(nonzero!(3u32)));
-        assert!(format!("{:?}", lim).len() > 0);
+        assert!(!format!("{:?}", lim).is_empty());
     }
 }

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -46,6 +46,10 @@ pub trait StateStore {
     fn measure_and_replace<T, F, E>(&self, key: &Self::Key, f: F) -> Result<T, E>
     where
         F: Fn(Option<Nanos>) -> Result<(T, Nanos), E>;
+
+    fn measure_and_peek<T, F, E>(&self, key: &Self::Key, f: F) -> Option<Result<T, E>>
+    where
+        F: Fn(Option<Nanos>) -> Result<(T, Nanos), E>;
 }
 
 /// A rate limiter.

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -46,10 +46,13 @@ pub trait StateStore {
     fn measure_and_replace<T, F, E>(&self, key: &Self::Key, f: F) -> Result<T, E>
     where
         F: Fn(Option<Nanos>) -> Result<(T, Nanos), E>;
-
+    /// `measure_and_peek` does the same as `measure_and_replace` except
+    /// it will not change the state. This is useful if you need to know the next
+    /// decision in advance
     fn measure_and_peek<T, F, E>(&self, key: &Self::Key, f: F) -> Option<Result<T, E>>
     where
         F: Fn(Option<Nanos>) -> Result<(T, Nanos), E>;
+    fn reset(&self, key: &Self::Key);
 }
 
 /// A rate limiter.

--- a/governor/src/state/direct.rs
+++ b/governor/src/state/direct.rs
@@ -116,6 +116,20 @@ where
                 self.clock.now(),
             )
     }
+
+    pub fn peek_n(
+        &self,
+        n: NonZeroU32,
+    ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<MW::NegativeOutcome>> {
+        self.gcra
+            .test_n_all_peek::<NotKeyed, C::Instant, S, MW>(
+                self.start,
+                &NotKeyed::NonKey,
+                n,
+                &self.state,
+                self.clock.now(),
+            )
+    }
 }
 
 #[cfg(feature = "std")]

--- a/governor/src/state/direct.rs
+++ b/governor/src/state/direct.rs
@@ -80,6 +80,15 @@ where
         )
     }
 
+    pub fn peek(&self) -> Result<MW::PositiveOutcome, MW::NegativeOutcome> {
+        self.gcra.peek_test::<NotKeyed, C::Instant, S, MW>(
+            self.start,
+            &NotKeyed::NonKey,
+            &self.state,
+            self.clock.now(),
+        )
+    }
+
     /// Allow *only all* `n` cells through the rate limiter.
     ///
     /// This method can succeed in only one way and fail in two ways:

--- a/governor/src/state/direct/future.rs
+++ b/governor/src/state/direct/future.rs
@@ -124,6 +124,6 @@ mod test {
     fn insufficient_capacity_impl_coverage() {
         let i = InsufficientCapacity(1);
         assert_eq!(i.0, i.clone().0);
-        assert!(format!("{}", i).len() > 0);
+        assert!(!format!("{}", i).is_empty());
     }
 }

--- a/governor/src/state/in_memory.rs
+++ b/governor/src/state/in_memory.rs
@@ -93,6 +93,9 @@ impl StateStore for InMemoryState {
     {
         Some(self.measure_and_peek_one(f))
     }
+    fn reset(&self, _key: &Self::Key) {
+        self.0.store(0, Ordering::Release);
+    }
 }
 
 impl Debug for InMemoryState {

--- a/governor/src/state/in_memory.rs
+++ b/governor/src/state/in_memory.rs
@@ -79,7 +79,8 @@ mod test {
         use std::thread;
 
         let mut state = Arc::new(InMemoryState(AtomicU64::new(0)));
-        let threads: Vec<thread::JoinHandle<_>> = (0..n_threads)
+
+        let hits: u64 = (0..n_threads)
             .map(|_| {
                 thread::spawn({
                     let state = Arc::clone(&state);
@@ -99,9 +100,7 @@ mod test {
                         hits
                     }
                 })
-            })
-            .collect();
-        let hits: u64 = threads.into_iter().map(|t| t.join().unwrap()).sum();
+            }).map(|t| t.join().unwrap()).sum();
         let value = Arc::get_mut(&mut state).unwrap().0.get_mut();
         (*value, hits)
     }
@@ -132,6 +131,6 @@ mod test {
     #[test]
     fn in_memory_state_impls() {
         let state = InMemoryState(AtomicU64::new(0));
-        assert!(format!("{:?}", state).len() > 0);
+        assert!(!format!("{:?}", state).is_empty());
     }
 }

--- a/governor/src/state/keyed.rs
+++ b/governor/src/state/keyed.rs
@@ -107,6 +107,10 @@ where
         )
     }
 
+    pub fn reset_key(&self, key: &K) {
+        self.state.reset(key);
+    }
+    
     /// Allow *only all* `n` cells through the rate limiter for the given key.
     ///
     /// This method can succeed in only one way and fail in two ways:
@@ -288,6 +292,8 @@ mod test {
             {
                 Some(f(None).map(|(res, _)| res))
             }
+
+            fn reset(&self, _key: &Self::Key) {}
         }
 
         impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for NaiveKeyedStateStore<K> {

--- a/governor/src/state/keyed.rs
+++ b/governor/src/state/keyed.rs
@@ -126,7 +126,7 @@ where
         key: &K,
         n: NonZeroU32,
     ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<MW::NegativeOutcome>> {
-        self.gcra.test_n_all_peek::<K, C::Instant, S, MW>(
+        self.gcra.test_n_all_and_update::<K, C::Instant, S, MW>(
             self.start,
             key,
             n,

--- a/governor/src/state/keyed.rs
+++ b/governor/src/state/keyed.rs
@@ -98,6 +98,15 @@ where
         )
     }
 
+    pub fn peek_key(&self, key: &K) -> Result<MW::PositiveOutcome, MW::NegativeOutcome> {
+        self.gcra.peek_test::<K, C::Instant, S, MW>(
+            self.start,
+            key,
+            &self.state,
+            self.clock.now(),
+        )
+    }
+
     /// Allow *only all* `n` cells through the rate limiter for the given key.
     ///
     /// This method can succeed in only one way and fail in two ways:

--- a/governor/src/state/keyed.rs
+++ b/governor/src/state/keyed.rs
@@ -281,6 +281,13 @@ mod test {
             {
                 f(None).map(|(res, _)| res)
             }
+
+            fn measure_and_peek<T, F, E>(&self, _key: &Self::Key, f: F) -> Option<Result<T, E>>
+            where
+                F: Fn(Option<Nanos>) -> Result<(T, Nanos), E>,
+            {
+                Some(f(None).map(|(res, _)| res))
+            }
         }
 
         impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for NaiveKeyedStateStore<K> {

--- a/governor/src/state/keyed.rs
+++ b/governor/src/state/keyed.rs
@@ -126,7 +126,7 @@ where
         key: &K,
         n: NonZeroU32,
     ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<MW::NegativeOutcome>> {
-        self.gcra.test_n_all_and_update::<K, C::Instant, S, MW>(
+        self.gcra.test_n_all_peek::<K, C::Instant, S, MW>(
             self.start,
             key,
             n,
@@ -134,6 +134,21 @@ where
             self.clock.now(),
         )
     }
+
+    pub fn peek_key_n(
+        &self,
+        key: &K,
+        n: NonZeroU32,
+    ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<MW::NegativeOutcome>> {
+        self.gcra.test_n_all_peek::<K, C::Instant, S, MW>(
+            self.start,
+            key,
+            n,
+            &self.state,
+            self.clock.now(),
+        )
+    }
+
 }
 
 /// Keyed rate limiters that can be "cleaned up".

--- a/governor/src/state/keyed/dashmap.rs
+++ b/governor/src/state/keyed/dashmap.rs
@@ -40,6 +40,10 @@ impl<K: Hash + Eq + Clone> StateStore for DashMapStateStore<K> {
         let entry = self.entry(key.clone()).or_default();
         Some((*entry).measure_and_peek_one(f))
     }
+
+    fn reset(&self, key: &Self::Key) {
+        self.remove(key);
+    }
 }
 
 /// # Keyed rate limiters - [`DashMap`]-backed

--- a/governor/src/state/keyed/dashmap.rs
+++ b/governor/src/state/keyed/dashmap.rs
@@ -27,6 +27,19 @@ impl<K: Hash + Eq + Clone> StateStore for DashMapStateStore<K> {
         let entry = self.entry(key.clone()).or_default();
         (*entry).measure_and_replace_one(f)
     }
+
+    fn measure_and_peek<T, F, E>(&self, key: &Self::Key, f: F) -> Option<Result<T, E>>
+    where
+        F: Fn(Option<Nanos>) -> Result<(T, Nanos), E>,
+    {
+        if let Some(v) = self.get(key) {
+            // fast path: measure existing entry
+            return Some(v.measure_and_peek_one(f));
+        }
+        // make an entry and measure that:
+        let entry = self.entry(key.clone()).or_default();
+        Some((*entry).measure_and_peek_one(f))
+    }
 }
 
 /// # Keyed rate limiters - [`DashMap`]-backed

--- a/governor/src/state/keyed/hashmap.rs
+++ b/governor/src/state/keyed/hashmap.rs
@@ -54,9 +54,12 @@ impl<K: Hash + Eq + Clone> StateStore for HashMapStateStore<K> {
             std::collections::hash_map::Entry::Occupied(occupied) => Some(occupied.get().measure_and_peek_one(f)),
             std::collections::hash_map::Entry::Vacant(_) => None,
         }
-        // entry.measure_and_peek_one(f)
     }
 
+    fn reset(&self, key: &Self::Key) {
+        let mut map = self.lock();
+        map.remove(key);
+    }
 }
 
 impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for HashMapStateStore<K> {

--- a/governor/tests/direct.rs
+++ b/governor/tests/direct.rs
@@ -37,6 +37,64 @@ fn rejects_too_many() {
 }
 
 #[test]
+fn peek_does_not_change_the_decision() {
+    let clock = FakeRelativeClock::default();
+    let lb = RateLimiter::direct_with_clock(Quota::per_second(nonzero!(2u32)), &clock);
+    let ms = Duration::from_millis(1);
+
+
+        // no key is always positive outcome
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek(), "Now: {:?}", clock.now());
+        }
+
+        // use up our burst capacity (2 in the first second):
+        assert_eq!(Ok(()), lb.check(), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek(), "Now: {:?}", clock.now());
+        }
+
+        clock.advance(ms);
+        assert_eq!(Ok(()), lb.check(), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek(), "Now: {:?}", clock.now());
+        }
+
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check(), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek(), "Now: {:?}", clock.now());
+        }
+
+        // should be ok again in 1s:
+        clock.advance(ms * 1000);
+        assert_eq!(Ok(()), lb.check(), "Now: {:?}", clock.now());
+        clock.advance(ms);
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek(), "Now: {:?}", clock.now());
+        }
+
+        assert_eq!(Ok(()), lb.check());
+
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check(), "{:?}", lb);
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek(), "Now: {:?}", clock.now());
+        }
+}
+
+#[test]
 fn all_1_identical_to_1() {
     let clock = FakeRelativeClock::default();
     let lb = RateLimiter::direct_with_clock(Quota::per_second(nonzero!(2u32)), &clock);

--- a/governor/tests/keyed_dashmap.rs
+++ b/governor/tests/keyed_dashmap.rs
@@ -163,6 +163,48 @@ fn peek_does_not_change_the_decision_n() {
     }
 }
 
+#[test]
+fn reset_does_work() {
+    let clock = FakeRelativeClock::default();
+    let lb = RateLimiter::hashmap_with_clock(Quota::per_second(nonzero!(2u32)), &clock);
+    let ms = Duration::from_millis(1);
+
+    for key in KEYS {
+        // use up our burst capacity (2 in the first second):
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+        clock.advance(ms);
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        lb.reset_key(key);
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+        clock.advance(ms);
+        lb.reset_key(key);
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+        clock.advance(ms);
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+    }
+}
+
 fn retained_keys<T: Clone + Hash + Eq + Copy + Ord>(
     keys: &[T],
     limiter: RateLimiter<

--- a/governor/tests/keyed_dashmap.rs
+++ b/governor/tests/keyed_dashmap.rs
@@ -47,6 +47,28 @@ fn rejects_too_many() {
 }
 
 #[test]
+fn rejects_too_many_n() {
+    let clock = FakeRelativeClock::default();
+    let lb = RateLimiter::dashmap_with_clock(Quota::per_second(nonzero!(2u32)), &clock);
+    let ms = Duration::from_millis(1);
+
+    for key in KEYS {
+        // use up our burst capacity (2 in the first second):
+        assert_eq!(Ok(()), lb.check_key_n(key, nonzero!(2u32)), "Now: {:?}", clock.now());
+        clock.advance(ms);
+
+        assert_ne!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        // should be ok again in 1s:
+        clock.advance(ms * 1000);
+        assert_eq!(Ok(()), lb.check_key_n(key, nonzero!(2u32)), "Now: {:?}", clock.now());
+        clock.advance(ms);
+
+        assert_ne!(Ok(()), lb.check_key(key), "{:?}", lb);
+    }
+}
+
+#[test]
 fn peek_does_not_change_the_decision() {
     let clock = FakeRelativeClock::default();
     let lb = RateLimiter::dashmap_with_clock(Quota::per_second(nonzero!(2u32)), &clock);
@@ -102,6 +124,42 @@ fn peek_does_not_change_the_decision() {
             clock.advance(ms);
             assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
         }
+    }
+}
+
+#[test]
+fn peek_does_not_change_the_decision_n() {
+    let clock = FakeRelativeClock::default();
+    let lb = RateLimiter::dashmap_with_clock(Quota::per_second(nonzero!(2u32)), &clock);
+    let ms = Duration::from_millis(1);
+
+    for key in KEYS {
+        // no key is always positive outcome
+        assert!(lb.peek_key_n(key, nonzero!(3u32)).is_err());
+        assert_eq!(Ok(()), lb.peek_key_n(key, nonzero!(2u32)), "Now: {:?}", clock.now());
+
+        // use up our burst capacity (2 in the first second):
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        assert_eq!(Ok(()), lb.peek_key_n(key, nonzero!(1u32)), "Now: {:?}", clock.now());
+        assert!(lb.peek_key_n(key, nonzero!(2u32)).is_err());
+
+        clock.advance(ms);
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        assert_ne!(Ok(()), lb.peek_key_n(key, nonzero!(2u32)), "Now: {:?}", clock.now());
+
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        assert_ne!(Ok(()), lb.peek_key_n(key, nonzero!(2u32)), "Now: {:?}", clock.now());
+
+        // should be ok again in 1s:
+        clock.advance(ms * 1000);
+        assert_eq!(Ok(()), lb.peek_key_n(key, nonzero!(2u32)), "Now: {:?}", clock.now());
+
+        assert_eq!(Ok(()), lb.check_key_n(key, nonzero!(2u32)),"Now: {:?}", clock.now());
+        assert!(lb.peek_key_n(key, nonzero!(2u32)).is_err());
     }
 }
 

--- a/governor/tests/keyed_dashmap.rs
+++ b/governor/tests/keyed_dashmap.rs
@@ -46,6 +46,65 @@ fn rejects_too_many() {
     }
 }
 
+#[test]
+fn peek_does_not_change_the_decision() {
+    let clock = FakeRelativeClock::default();
+    let lb = RateLimiter::dashmap_with_clock(Quota::per_second(nonzero!(2u32)), &clock);
+    let ms = Duration::from_millis(1);
+
+    for key in KEYS {
+        // no key is always positive outcome
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        // use up our burst capacity (2 in the first second):
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        clock.advance(ms);
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        // should be ok again in 1s:
+        clock.advance(ms * 1000);
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+        clock.advance(ms);
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        assert_eq!(Ok(()), lb.check_key(key));
+
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check_key(key), "{:?}", lb);
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+    }
+}
+
 fn retained_keys<T: Clone + Hash + Eq + Copy + Ord>(
     keys: &[T],
     limiter: RateLimiter<

--- a/governor/tests/keyed_hashmap.rs
+++ b/governor/tests/keyed_hashmap.rs
@@ -44,6 +44,65 @@ fn rejects_too_many() {
     }
 }
 
+#[test]
+fn peek_does_not_change_the_decision() {
+    let clock = FakeRelativeClock::default();
+    let lb = RateLimiter::hashmap_with_clock(Quota::per_second(nonzero!(2u32)), &clock);
+    let ms = Duration::from_millis(1);
+
+    for key in KEYS {
+        // no key is always positive outcome
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        // use up our burst capacity (2 in the first second):
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        clock.advance(ms);
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+        
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        // should be ok again in 1s:
+        clock.advance(ms * 1000);
+        assert_eq!(Ok(()), lb.check_key(key), "Now: {:?}", clock.now());
+        clock.advance(ms);
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_eq!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+
+        assert_eq!(Ok(()), lb.check_key(key));
+
+        clock.advance(ms);
+        assert_ne!(Ok(()), lb.check_key(key), "{:?}", lb);
+
+        for _ in 0..10 {
+            clock.advance(ms);
+            assert_ne!(Ok(()), lb.peek_key(key), "Now: {:?}", clock.now());
+        }
+    }
+}
+
 fn retained_keys<T: Clone + Hash + Eq + Copy + Ord>(
     limiter: RateLimiter<
         T,

--- a/governor/tests/middleware.rs
+++ b/governor/tests/middleware.rs
@@ -23,9 +23,7 @@ impl RateLimitingMiddleware<<FakeRelativeClock as clock::Clock>::Instant> for My
         _key: &K,
         _limiter: impl Into<StateSnapshot>,
         _start_time: <FakeRelativeClock as clock::Clock>::Instant,
-    ) -> Self::NegativeOutcome {
-        ()
-    }
+    ) -> Self::NegativeOutcome {}
 }
 
 #[test]

--- a/governor/tests/proptests.rs
+++ b/governor/tests/proptests.rs
@@ -4,7 +4,7 @@ use governor::{
     clock::{Clock, FakeRelativeClock},
     Quota, RateLimiter,
 };
-use proptest::prelude::prop::test_runner::FileFailurePersistence;
+use proptest::prelude::prop::test_runner::{Config, FileFailurePersistence};
 use std::num::NonZeroU32;
 use std::time::Duration;
 
@@ -22,11 +22,12 @@ impl Arbitrary for Count {
 }
 
 fn test_config() -> ProptestConfig {
-    let mut cfg = ProptestConfig::default();
-    cfg.failure_persistence = Some(Box::new(FileFailurePersistence::WithSource("regressions")));
-    //cfg.timeout = 20;
-    cfg.verbose = 0; // 2 for extra verbosity;
-    cfg
+    // add timeout if necessary e.g. timeout: 20,
+    Config {
+        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("regressions"))),
+        verbose: 0, // 2 for extra verbosity
+        ..Default::default()
+    }
 }
 
 #[cfg(feature = "std")]

--- a/governor/tests/sinks.rs
+++ b/governor/tests/sinks.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 #[cfg(feature = "jitter")]
 use governor::Jitter;
-
+#[allow(clippy::unit_cmp)]
 #[test]
 fn sink() {
     let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
@@ -30,7 +30,7 @@ fn sink() {
 
     let result = sink.get_ref();
     assert_eq!(result.len(), 12);
-    assert!(result.into_iter().all(|&elt| elt == ()));
+    assert!(result.iter().all(|&elt| elt == ()));
 }
 
 #[test]
@@ -47,6 +47,7 @@ fn auxilliary_sink_methods() {
 
 #[cfg(all(feature = "jitter", test))]
 #[cfg_attr(feature = "jitter", test)]
+#[allow(clippy::unit_cmp)]
 fn sink_with_jitter() {
     let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
     let mut sink =


### PR DESCRIPTION
Hi Andreas,

This might be a weird PR, but I have a use case for it. I am rate-limiting login failures, and thus would like to know in advance before I send a request to the rather costly authentication, what the decision would be, so in case of a failure I reject right away.
I considered wrapping first, but that would have meant to deal with the whole rate limiter for an individual decision.
Also, I wanted to have the ability to remove a key from the rate limiter, if some condition happens. The use case here is a user login. If it fails too often it gets rate limited, but if it succeeds it is reset.

I am a rather average coder, so I basically duplicated the code. But I am happy to take suggestions. Two things come to mind:
Call `check_key` for `peek_check_key` instead of duplicating the code. Use `fetch_and_update` instead of the `compare_exchange_weak` while loop.

I added more tests, as I intend to use this code in production. Please let me know what you think.
