### PR TITLE
Change the API for check_n / check_n_keyed / until_n / until_n_keyed

### DIFF
--- a/governor/CHANGELOG.md
+++ b/governor/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+* The API for `.check_n` and `.until_n` (and their keyed counterpart)
+  have changed to return a nested `Result` - the outer indicating
+  whether the check could ever succeed and the inner one indicating
+  the rate limiting result, if it could succeed.
+
 ## [[0.5.1](https://docs.rs/governor/0.5.1/governor/)] - 2022-11-29
 
 ### Changed

--- a/governor/src/errors.rs
+++ b/governor/src/errors.rs
@@ -1,28 +1,37 @@
-/// Gives additional information about the negative outcome of a batch
-/// cell decision.
-///
-/// Since batch queries can be made for batch sizes bigger than the
-/// rate limiter parameter could accomodate, there are now two
-/// possible negative outcomes:
-///
-///   * `BatchNonConforming` - the query is valid but the Decider can
-///     not accomodate them.
-///
-///   * `InsufficientCapacity` - the query was invalid as the rate
-///     limite parameters can never accomodate the number of cells
-///     queried for.
-#[derive(Debug, PartialEq, Eq)]
-pub enum NegativeMultiDecision<E> {
-    /// A batch of cells (the first argument) is non-conforming and
-    /// can not be let through at this time. The second argument gives
-    /// information about when that batch of cells might be let
-    /// through again (not accounting for thundering herds and other,
-    /// simultaneous decisions).
-    BatchNonConforming(u32, E),
+use std::fmt;
 
-    /// The number of cells tested (the first argument) is larger than
-    /// the bucket's capacity, which means the decision can never have
-    /// a conforming result. The argument gives the maximum number of
-    /// cells that could ever have a conforming result.
-    InsufficientCapacity(u32),
+/// Error indicating that the number of cells tested (the first
+/// argument) is larger than the bucket's capacity.
+///
+/// This means the decision can never have a conforming result. The
+/// argument gives the maximum number of cells that could ever have a
+/// conforming result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InsufficientCapacity(pub u32);
+
+impl fmt::Display for InsufficientCapacity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "required number of cells {} exceeds bucket's capacity",
+            self.0
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InsufficientCapacity {}
+
+#[cfg(all(feature = "std", test))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn coverage() {
+        let display_output = format!("{}", InsufficientCapacity(3));
+        assert!(display_output.contains("3"));
+        let debug_output = format!("{:?}", InsufficientCapacity(3));
+        assert!(debug_output.contains("3"));
+        assert_eq!(InsufficientCapacity(3), InsufficientCapacity(3));
+    }
 }

--- a/governor/src/state/direct.rs
+++ b/governor/src/state/direct.rs
@@ -9,9 +9,10 @@ use std::num::NonZeroU32;
 
 use crate::{
     clock,
+    errors::InsufficientCapacity,
     middleware::{NoOpMiddleware, RateLimitingMiddleware},
     state::InMemoryState,
-    NegativeMultiDecision, Quota,
+    Quota,
 };
 
 /// The "this state store does not use keys" key type.
@@ -97,7 +98,7 @@ where
     pub fn check_n(
         &self,
         n: NonZeroU32,
-    ) -> Result<MW::PositiveOutcome, NegativeMultiDecision<MW::NegativeOutcome>> {
+    ) -> Result<Result<MW::PositiveOutcome, MW::NegativeOutcome>, InsufficientCapacity> {
         self.gcra
             .test_n_all_and_update::<NotKeyed, C::Instant, S, MW>(
                 self.start,

--- a/governor/tests/direct.rs
+++ b/governor/tests/direct.rs
@@ -1,6 +1,6 @@
 use governor::{
     clock::{Clock, FakeRelativeClock},
-    NegativeMultiDecision, Quota, RateLimiter,
+    InsufficientCapacity, Quota, RateLimiter,
 };
 use nonzero_ext::nonzero;
 use std::time::Duration;
@@ -44,21 +44,21 @@ fn all_1_identical_to_1() {
     let one = nonzero!(1u32);
 
     // use up our burst capacity (2 in the first second):
-    assert_eq!(Ok(()), lb.check_n(one), "Now: {:?}", clock.now());
+    assert_eq!(Ok(Ok(())), lb.check_n(one), "Now: {:?}", clock.now());
     clock.advance(ms);
-    assert_eq!(Ok(()), lb.check_n(one), "Now: {:?}", clock.now());
+    assert_eq!(Ok(Ok(())), lb.check_n(one), "Now: {:?}", clock.now());
 
     clock.advance(ms);
-    assert_ne!(Ok(()), lb.check_n(one), "Now: {:?}", clock.now());
+    assert_ne!(Ok(Ok(())), lb.check_n(one), "Now: {:?}", clock.now());
 
     // should be ok again in 1s:
     clock.advance(ms * 1000);
-    assert_eq!(Ok(()), lb.check_n(one), "Now: {:?}", clock.now());
+    assert_eq!(Ok(Ok(())), lb.check_n(one), "Now: {:?}", clock.now());
     clock.advance(ms);
-    assert_eq!(Ok(()), lb.check_n(one));
+    assert_eq!(Ok(Ok(())), lb.check_n(one));
 
     clock.advance(ms);
-    assert_ne!(Ok(()), lb.check_n(one), "{:?}", lb);
+    assert_ne!(Ok(Ok(())), lb.check_n(one), "{:?}", lb);
 }
 
 #[test]
@@ -68,20 +68,20 @@ fn never_allows_more_than_capacity_all() {
     let ms = Duration::from_millis(1);
 
     // Use up the burst capacity:
-    assert_eq!(Ok(()), lb.check_n(nonzero!(2u32)), "Now: {:?}", clock.now());
-    assert_eq!(Ok(()), lb.check_n(nonzero!(2u32)), "Now: {:?}", clock.now());
+    assert_eq!(Ok(Ok(())), lb.check_n(nonzero!(2u32)));
+    assert_eq!(Ok(Ok(())), lb.check_n(nonzero!(2u32)));
 
     clock.advance(ms);
-    assert_ne!(Ok(()), lb.check_n(nonzero!(2u32)), "Now: {:?}", clock.now());
+    assert_ne!(Ok(Ok(())), lb.check_n(nonzero!(2u32)));
 
     // should be ok again in 1s:
     clock.advance(ms * 1000);
-    assert_eq!(Ok(()), lb.check_n(nonzero!(2u32)), "Now: {:?}", clock.now());
+    assert_eq!(Ok(Ok(())), lb.check_n(nonzero!(2u32)));
     clock.advance(ms);
-    assert_eq!(Ok(()), lb.check_n(nonzero!(2u32)));
+    assert_eq!(Ok(Ok(())), lb.check_n(nonzero!(2u32)));
 
     clock.advance(ms);
-    assert_ne!(Ok(()), lb.check_n(nonzero!(2u32)), "{:?}", lb);
+    assert_ne!(Ok(Ok(())), lb.check_n(nonzero!(2u32)), "{:?}", lb);
 }
 
 #[test]
@@ -91,11 +91,11 @@ fn rejects_too_many_all() {
     let ms = Duration::from_millis(1);
 
     // Should not allow the first 15 cells on a capacity 5 bucket:
-    assert_ne!(Ok(()), lb.check_n(nonzero!(15u32)));
+    assert_ne!(Ok(Ok(())), lb.check_n(nonzero!(15u32)));
 
     // After 3 and 20 seconds, it should not allow 15 on that bucket either:
     clock.advance(ms * 3 * 1000);
-    assert_ne!(Ok(()), lb.check_n(nonzero!(15u32)));
+    assert_ne!(Ok(Ok(())), lb.check_n(nonzero!(15u32)));
 }
 
 #[test]
@@ -103,18 +103,9 @@ fn all_capacity_check_rejects_excess() {
     let clock = FakeRelativeClock::default();
     let lb = RateLimiter::direct_with_clock(Quota::per_second(nonzero!(5u32)), &clock);
 
-    assert_eq!(
-        Err(NegativeMultiDecision::InsufficientCapacity(5)),
-        lb.check_n(nonzero!(15u32))
-    );
-    assert_eq!(
-        Err(NegativeMultiDecision::InsufficientCapacity(5)),
-        lb.check_n(nonzero!(6u32))
-    );
-    assert_eq!(
-        Err(NegativeMultiDecision::InsufficientCapacity(5)),
-        lb.check_n(nonzero!(7u32))
-    );
+    assert_eq!(Err(InsufficientCapacity(5)), lb.check_n(nonzero!(15u32)));
+    assert_eq!(Err(InsufficientCapacity(5)), lb.check_n(nonzero!(6u32)));
+    assert_eq!(Err(InsufficientCapacity(5)), lb.check_n(nonzero!(7u32)));
 }
 
 #[test]

--- a/governor/tests/keyed_dashmap.rs
+++ b/governor/tests/keyed_dashmap.rs
@@ -155,7 +155,7 @@ fn dashmap_shrink_to_fit() {
 
     assert_eq!(
         lim.check_key_n(&"long-lived".to_string(), nonzero!(10_u32)),
-        Ok(())
+        Ok(Ok(()))
     );
     assert_eq!(lim.check_key(&"short-lived".to_string()), Ok(()));
 

--- a/governor/tests/keyed_hashmap.rs
+++ b/governor/tests/keyed_hashmap.rs
@@ -149,7 +149,7 @@ fn hashmap_shrink_to_fit() {
 
     assert_eq!(
         lim.check_key_n(&"long-lived".to_string(), nonzero!(10_u32)),
-        Ok(())
+        Ok(Ok(()))
     );
     assert_eq!(lim.check_key(&"short-lived".to_string()), Ok(()));
 


### PR DESCRIPTION
Previously, it returned an enum whose variants had different jobs: one to indicate that a usage error had occurred and one to indicate the rate limiting result. That's not ideal as it complicated every use of the rate limiter.

Instead, return a nested result: The outermost can be used with the try/? operator, to ensure usage errors get propagated through, and then the one can be used like you would a non-`n` usage of the rate limiter.

This is pretty incompatible to what was there before, so next release is a major one if this goes in.