### PR TITLE
Correctly report quota in StateInformationMiddleware

### DIFF
--- a/governor/CHANGELOG.md
+++ b/governor/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+* Fixed quota reporting for positive rate limiting decisions when
+  `StateInformationMiddleware` is in use with a real clock. Reported
+  in [#157](https://github.com/antifuchs/governor/issues/157)
+
+### Contributors
+* [@AaronErhardt](https://github.com/AaronErhardt)
+
 ## [[0.5.0](https://docs.rs/governor/0.5.0/governor/)] - 2022-09-19
 
 ### Changed
@@ -20,7 +28,7 @@
 * Upgraded `dashmap` back [to 5.1.0](https://github.com/antifuchs/governor/pull/110).
 * Upgraded `parking_lot` [to 0.12.0](https://github.com/antifuchs/governor/pull/109).
 
-## Internal
+### Internal
 * Migrated the `governor` code base to [cargo
   workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html).
 

--- a/governor/src/middleware.rs
+++ b/governor/src/middleware.rs
@@ -212,10 +212,15 @@ pub trait RateLimitingMiddleware<P: clock::Reference>: fmt::Debug {
     ) -> Self::NegativeOutcome;
 }
 
-#[derive(Debug)]
 /// A middleware that does nothing and returns `()` in the positive outcome.
 pub struct NoOpMiddleware<P: clock::Reference = <clock::DefaultClock as clock::Clock>::Instant> {
     phantom: PhantomData<P>,
+}
+
+impl<P: clock::Reference> std::fmt::Debug for NoOpMiddleware<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NoOpMiddleware")
+    }
 }
 
 impl<P: clock::Reference> RateLimitingMiddleware<P> for NoOpMiddleware<P> {
@@ -283,7 +288,7 @@ mod test {
                     phantom: PhantomData::<Duration>,
                 }
             ),
-            "NoOpMiddleware { phantom: PhantomData }"
+            "NoOpMiddleware"
         );
     }
 }

--- a/governor/src/middleware.rs
+++ b/governor/src/middleware.rs
@@ -106,11 +106,7 @@ impl StateSnapshot {
     /// If this state snapshot is based on a negative rate limiting
     /// outcome, this method returns 0.
     pub fn remaining_burst_capacity(&self) -> u32 {
-        let t0 = if self.time_of_measurement.as_u64() == 0 {
-            self.time_of_measurement + self.t
-        } else {
-            self.time_of_measurement
-        };
+        let t0 = self.time_of_measurement + self.t;
         (cmp::min(
             (t0 + self.tau).saturating_sub(self.tat).as_u64(),
             self.tau.as_u64(),

--- a/governor/tests/future.rs
+++ b/governor/tests/future.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-const WAIT_UNTIL_PROCEEDS: u64 = 50;
+/// The time that our "real" clock tests may take, indicating that no
+/// blocking waits have occurred.
+const MAX_TEST_RUN_DURATION: Duration = Duration::from_micros(200);
 
 #[test]
 fn pauses() {
@@ -55,26 +57,26 @@ fn pauses_keyed() {
 
 #[test]
 fn proceeds() {
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+    let lim = RateLimiter::direct(Quota::per_second(nonzero!(2u32)));
     let i = Instant::now();
     block_on(lim.until_ready());
-    assert_le!(i.elapsed(), Duration::from_micros(WAIT_UNTIL_PROCEEDS));
+    assert_le!(i.elapsed(), MAX_TEST_RUN_DURATION);
 }
 
 #[test]
 fn proceeds_n() {
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+    let lim = RateLimiter::direct(Quota::per_second(nonzero!(3u32)));
     let i = Instant::now();
-    block_on(lim.until_n_ready(nonzero!(10u32))).unwrap();
-    assert_le!(i.elapsed(), Duration::from_micros(WAIT_UNTIL_PROCEEDS));
+    block_on(lim.until_n_ready(nonzero!(2u32))).unwrap();
+    assert_le!(i.elapsed(), MAX_TEST_RUN_DURATION);
 }
 
 #[test]
 fn proceeds_keyed() {
-    let lim = RateLimiter::keyed(Quota::per_second(nonzero!(10u32)));
+    let lim = RateLimiter::keyed(Quota::per_second(nonzero!(2u32)));
     let i = Instant::now();
     block_on(lim.until_key_ready(&1u32));
-    assert_le!(i.elapsed(), Duration::from_micros(WAIT_UNTIL_PROCEEDS));
+    assert_le!(i.elapsed(), MAX_TEST_RUN_DURATION);
 }
 
 #[test]

--- a/governor/tests/middleware.rs
+++ b/governor/tests/middleware.rs
@@ -94,16 +94,22 @@ fn state_snapshot_tracks_quota_accurately() {
     assert_eq!(lim.check().map(|s| s.remaining_burst_capacity()), Ok(1));
     assert_eq!(lim.check().map(|s| s.remaining_burst_capacity()), Ok(0));
     assert_eq!(lim.check().map_err(|_| ()), Err(()), "should rate limit");
+}
 
-    // Now with a real clock
+#[test]
+#[cfg(feature = "std")]
+fn state_snapshot_tracks_quota_accurately_with_real_clock() {
+    use governor::middleware::StateInformationMiddleware;
+    use governor::{Quota, RateLimiter};
+    use std::num::NonZeroU32;
+    use std::time::Duration;
+
+    let burst_size = NonZeroU32::new(2).unwrap();
+    let period = Duration::from_millis(90);
+    let quota = Quota::with_period(period).unwrap().allow_burst(burst_size);
     let lim = RateLimiter::direct(quota).with_middleware::<StateInformationMiddleware>();
 
-    assert_eq!(
-        lim.check().unwrap().remaining_burst_capacity(),
-        1,
-        "{:?}",
-        lim
-    ); // <- This returns 0 instead
+    assert_eq!(lim.check().unwrap().remaining_burst_capacity(), 1);
     assert_eq!(lim.check().unwrap().remaining_burst_capacity(), 0);
     assert_eq!(lim.check().map_err(|_| ()), Err(()), "should rate limit");
 }


### PR DESCRIPTION
This fix was previously prevented from passing tests by flakey quanta clock tests. I believe by lengthening the intervals and reducing the quota (thereby increasing the "time value" of each element), we can de-flake these tests somewhat, which lets this fix correctly pass.

Now, the problem was that the correct quota was reported only if a fake clock was used (i.e. if it remains at the zero nanosecond) - instead, we correctly compute the remaining capacity in all cases now.

This also extends the "remaining capacity" test by a few cases including a real clock.

Fixes #157 