### PR TITLE
Add Default{Direct,Keyed}RateLimiter type aliases

### DIFF
--- a/governor/CHANGELOG.md
+++ b/governor/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+* Type aliases `DefaultDirectRateLimiter` and
+  `DefaultKeyedRateLimiter` to cut down on type-typing of typical rate
+  limiters in struct and function definitions. Requested in
+  [#85](https://github.com/antifuchs/governor/issues/85).
+
 ### Changed
 * The API for `.check_n` and `.until_n` (and their keyed counterpart)
   have changed to return a nested `Result` - the outer indicating

--- a/governor/src/_guide.rs
+++ b/governor/src/_guide.rs
@@ -85,6 +85,28 @@
 //! [KeyedStateStore][crate::state::keyed::KeyedStateStore] trait, and optionally the
 //! [ShrinkableKeyedStateStore][crate::state::keyed::ShrinkableKeyedStateStore] trait.
 //!
+//! # Type signatures for rate limiters
+//!
+//! Rate limiters tend to be long-lived, and need to be stored
+//! somewhere - sometimes in struct fields, or even just to pass in
+//! function arguments. The [`crate::RateLimiter`] type signatures
+//! tend to be pretty unwieldy for that, so this crate exports a pair
+//! of handy type aliases, [`crate::DefaultDirectRateLimiter`] and
+//! [`crate::DefaultDirectRateLimiter`].
+//!
+//! Here's an example for embedding a direct rate limiter in a struct:
+//!
+//! ```rust
+//! # use governor::DefaultDirectRateLimiter;
+//! struct MyApiClient {
+//!     limiter: DefaultDirectRateLimiter,
+//! }
+//! ```
+//!
+//! If you need to provide a different clock, or a different
+//! implementation of the keyed state, you will still have to fall
+//! back to the regular type.
+//!
 //! # Data ownership and references to rate limiters
 //!
 //! `governor`'s rate limiter state is not hidden behind an [interior

--- a/governor/src/lib.rs
+++ b/governor/src/lib.rs
@@ -68,3 +68,18 @@ pub mod prelude {
     #[cfg(feature = "std")]
     pub use crate::state::direct::StreamRateLimitExt;
 }
+
+/// A rate limiter representing a single item of state in memory, running on the default clock.
+///
+/// See the [`RateLimiter`] documentation for details.
+pub type DefaultDirectRateLimiter<
+    MW = middleware::NoOpMiddleware<<clock::DefaultClock as clock::Clock>::Instant>,
+> = RateLimiter<state::direct::NotKeyed, state::InMemoryState, clock::DefaultClock, MW>;
+
+/// A rate limiter with one state per key, running on the default clock.
+///
+/// See the [`RateLimiter`] documentation for details.
+pub type DefaultKeyedRateLimiter<
+    K,
+    MW = middleware::NoOpMiddleware<<clock::DefaultClock as clock::Clock>::Instant>,
+> = RateLimiter<K, state::keyed::DefaultKeyedStateStore<K>, clock::DefaultClock, MW>;

--- a/governor/tests/direct.rs
+++ b/governor/tests/direct.rs
@@ -1,6 +1,6 @@
 use governor::{
     clock::{Clock, FakeRelativeClock},
-    InsufficientCapacity, Quota, RateLimiter,
+    DefaultDirectRateLimiter, InsufficientCapacity, Quota, RateLimiter,
 };
 use nonzero_ext::nonzero;
 use std::time::Duration;
@@ -153,4 +153,12 @@ fn actual_threadsafety() {
     assert_ne!(Ok(()), lim.check());
     clock.advance(ms * 998);
     assert_eq!(Ok(()), lim.check());
+}
+
+#[test]
+fn default_direct() {
+    let clock = FakeRelativeClock::default();
+    let limiter: DefaultDirectRateLimiter =
+        RateLimiter::direct_with_clock(Quota::per_second(nonzero!(20u32)), &clock);
+    assert_eq!(Ok(()), limiter.check());
 }

--- a/governor/tests/direct.rs
+++ b/governor/tests/direct.rs
@@ -157,7 +157,7 @@ fn actual_threadsafety() {
 
 #[test]
 fn default_direct() {
-    let clock = FakeRelativeClock::default();
+    let clock = governor::clock::DefaultClock::default();
     let limiter: DefaultDirectRateLimiter =
         RateLimiter::direct_with_clock(Quota::per_second(nonzero!(20u32)), &clock);
     assert_eq!(Ok(()), limiter.check());

--- a/governor/tests/keyed.rs
+++ b/governor/tests/keyed.rs
@@ -1,0 +1,9 @@
+use governor::{DefaultKeyedRateLimiter, Quota, RateLimiter};
+use nonzero_ext::nonzero;
+
+#[test]
+fn default_keyed() {
+    let limiter: DefaultKeyedRateLimiter<u32> =
+        RateLimiter::keyed(Quota::per_second(nonzero!(20u32)));
+    assert_eq!(Ok(()), limiter.check_key(&1));
+}


### PR DESCRIPTION
This fixes #85. That issue has been open very long and now that I had to pass a rate limiter in a function argument, I am feeling the pain too. Let's fix this once and for all.