### PR TITLE
Remove the quanta reference instant

### DIFF
--- a/governor/CHANGELOG.md
+++ b/governor/CHANGELOG.md
@@ -19,9 +19,7 @@
   0.11.0](https://github.com/metrics-rs/quanta/blob/main/CHANGELOG.md#0110---2023-03-24).
   This change also adds a reference u64 instant to all instances of
   the `QuantaClock` structure. All quanta timekeeping used by governor
-  will now be relative to that reference instant. Note that this
-  increases the size of each `RateLimiter` by the width of a u64, to
-  accommodate that reference instant.
+  will now be relative to that reference instant.
 * Some parts of the documentation for burst sizes has been rephrased
   to be less confusing.
 

--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -15,14 +15,12 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 pub struct QuantaClock {
     clock: quanta::Clock,
-    reference: u64,
 }
 
 impl Default for QuantaClock {
     fn default() -> Self {
         let clock = quanta::Clock::default();
-        let reference = clock.raw();
-        Self { clock, reference }
+        Self { clock }
     }
 }
 
@@ -31,7 +29,7 @@ impl Clock for QuantaClock {
 
     fn now(&self) -> Self::Instant {
         let nowish = self.clock.raw();
-        QuantaInstant(Nanos::from(self.clock.delta(self.reference, nowish)))
+        QuantaInstant(Nanos::from(self.clock.delta(0, nowish)))
     }
 }
 


### PR DESCRIPTION
We can always pass a 0 (which stands for an arbitrary point in time, but so does the original reference) to delta, which means there's one fewer 64 bit integer to keep around per RateLimiter.

