### PR TITLE
Use direct nanosecond operations in quanta, bring speed back to baseline

### DIFF
--- a/governor/CHANGELOG.md
+++ b/governor/CHANGELOG.md
@@ -16,10 +16,11 @@
   whether the check could ever succeed and the inner one indicating
   the rate limiting result, if it could succeed.
 * Updated the [quanta dependency to
-  0.11.0](https://github.com/metrics-rs/quanta/blob/main/CHANGELOG.md#0110---2023-03-24).
+  0.11.1](https://github.com/metrics-rs/quanta/blob/main/CHANGELOG.md#0110---2023-03-24).
   This change also adds a reference u64 instant to all instances of
-  the `QuantaClock` structure. All quanta timekeeping used by governor
-  will now be relative to that reference instant.
+  the `QuantaUpkeepClock` structure. All lower-resolution quanta
+  timekeeping used by governor will now be relative to that reference
+  instant.
 * Some parts of the documentation for burst sizes has been rephrased
   to be less confusing.
 

--- a/governor/Cargo.toml
+++ b/governor/Cargo.toml
@@ -48,7 +48,7 @@ futures-timer = { version = "3.0.2", optional = true }
 futures = { version = "0.3.5", optional = true }
 rand = { version = "0.8.0", optional = true }
 dashmap = { version = "5.1.0", optional = true }
-quanta = { version = "0.11.0", optional = true }
+quanta = { version = "0.11.1", optional = true }
 no-std-compat = { version = "0.4.1", features = [ "alloc" ] }
 cfg-if = "1.0"
 

--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -29,7 +29,7 @@ impl Clock for QuantaClock {
 
     fn now(&self) -> Self::Instant {
         let nowish = self.clock.raw();
-        QuantaInstant(Nanos::from(self.clock.delta(0, nowish)))
+        QuantaInstant(Nanos::new(self.clock.delta_as_nanos(0, nowish)))
     }
 }
 


### PR DESCRIPTION
This uses https://github.com/metrics-rs/quanta/pull/86 to avoid roundtripping nanosecond counts through Duration, which does a bunch of integer math on construction and deconstruction, which we don't even need (unless we exceed the 270 years of governor's useful operational uptime).

In benchmarks, this brings speeds back to the baseline pre-quanta-0.11 (see #175)